### PR TITLE
Refactor buffer allocator member names

### DIFF
--- a/include/cat_buffer.h
+++ b/include/cat_buffer.h
@@ -40,10 +40,10 @@ typedef void (*cat_buffer_free_function_t)(char *value);
 
 typedef struct
 {
-    cat_buffer_alloc_function_t alloc;
-    cat_buffer_realloc_function_t realloc;
-    cat_buffer_update_function_t update;
-    cat_buffer_free_function_t free;
+    cat_buffer_alloc_function_t alloc_function;
+    cat_buffer_realloc_function_t realloc_function;
+    cat_buffer_update_function_t update_function;
+    cat_buffer_free_function_t free_function;
 } cat_buffer_allocator_t;
 
 extern CAT_API cat_buffer_allocator_t cat_buffer_allocator;

--- a/src/cat_buffer.c
+++ b/src/cat_buffer.c
@@ -75,9 +75,9 @@ CAT_API cat_bool_t cat_buffer_module_init(void)
 CAT_API cat_bool_t cat_buffer_register_allocator(const cat_buffer_allocator_t *allocator)
 {
     if (
-        allocator->alloc == NULL ||
-        allocator->realloc == NULL ||
-        allocator->free == NULL
+        allocator->alloc_function == NULL ||
+        allocator->realloc_function == NULL ||
+        allocator->free_function == NULL
     ) {
         cat_update_last_error(CAT_EINVAL, "Allocator must be filled (except update)");
         return cat_false;
@@ -103,7 +103,7 @@ static cat_always_inline cat_bool_t cat_buffer__alloc(cat_buffer_t *buffer, size
         return cat_true;
     }
 
-    value = cat_buffer_allocator.alloc(size);
+    value = cat_buffer_allocator.alloc_function(size);
 
     if (unlikely(value == NULL)) {
         return cat_false;
@@ -118,8 +118,8 @@ static cat_always_inline cat_bool_t cat_buffer__alloc(cat_buffer_t *buffer, size
 static cat_always_inline void cat_buffer__update(cat_buffer_t *buffer, size_t new_length)
 {
     buffer->length = new_length;
-    if (cat_buffer_allocator.update != NULL) {
-        cat_buffer_allocator.update(buffer->value, new_length);
+    if (cat_buffer_allocator.update_function != NULL) {
+        cat_buffer_allocator.update_function(buffer->value, new_length);
     }
 }
 
@@ -170,7 +170,7 @@ CAT_API cat_bool_t cat_buffer_realloc(cat_buffer_t *buffer, size_t new_size)
         return cat_true;
     }
 
-    new_value = cat_buffer_allocator.realloc(buffer->value, buffer->length, new_size);
+    new_value = cat_buffer_allocator.realloc_function(buffer->value, buffer->length, new_size);
 
     if (unlikely(new_value == NULL)) {
         return cat_false;
@@ -309,7 +309,7 @@ CAT_API void cat_buffer_close(cat_buffer_t *buffer)
     if (buffer->value == NULL) {
         return;
     }
-    cat_buffer_allocator.free(buffer->value);
+    cat_buffer_allocator.free_function(buffer->value);
     cat_buffer__init(buffer);
 }
 

--- a/tests/test_cat_buffer.cc
+++ b/tests/test_cat_buffer.cc
@@ -24,7 +24,7 @@
 
 bool operator==(const cat_buffer_allocator_t& lhs, const cat_buffer_allocator_t& rhs)
 {
-    return lhs.alloc == rhs.alloc && lhs.free == rhs.free && lhs.realloc == rhs.realloc && lhs.update == rhs.update;
+    return lhs.alloc_function == rhs.alloc_function && lhs.free_function == rhs.free_function && lhs.realloc_function == rhs.realloc_function && lhs.update_function == rhs.update_function;
 }
 
 bool operator==(const cat_buffer_t& lhs, const cat_buffer_t& rhs)
@@ -39,9 +39,9 @@ TEST(cat_buffer, alloc_standard)
 {
     char *prt;
 
-    prt = cat_buffer_allocator.alloc(CAT_TEST_DEFAULT_BUFFER_SIZE);
+    prt = cat_buffer_allocator.alloc_function(CAT_TEST_DEFAULT_BUFFER_SIZE);
     ASSERT_NE(nullptr, prt);
-    cat_buffer_allocator.free(prt);
+    cat_buffer_allocator.free_function(prt);
 }
 
 TEST(cat_buffer, realloc_standard)
@@ -49,11 +49,11 @@ TEST(cat_buffer, realloc_standard)
     char *src;
     char *dst;
 
-    src = cat_buffer_allocator.alloc(CAT_TEST_DEFAULT_BUFFER_SIZE);
+    src = cat_buffer_allocator.alloc_function(CAT_TEST_DEFAULT_BUFFER_SIZE);
     ASSERT_NE(nullptr, src);
 
-    dst = cat_buffer_allocator.realloc(src, CAT_TEST_DEFAULT_BUFFER_SIZE, CAT_TEST_DEFAULT_BUFFER_SIZE * 2);
-    DEFER(cat_buffer_allocator.free(dst));
+    dst = cat_buffer_allocator.realloc_function(src, CAT_TEST_DEFAULT_BUFFER_SIZE, CAT_TEST_DEFAULT_BUFFER_SIZE * 2);
+    DEFER(cat_buffer_allocator.free_function(dst));
     ASSERT_NE(nullptr, dst);
     ASSERT_NE(src, dst);
 }
@@ -65,7 +65,7 @@ TEST(cat_buffer, realloc_standard_data)
     /* src will be free, so we need src_tmp */
     char src_tmp[CAT_TEST_DEFAULT_BUFFER_SIZE + 1];
 
-    src = cat_buffer_allocator.alloc(CAT_TEST_DEFAULT_BUFFER_SIZE + 1);
+    src = cat_buffer_allocator.alloc_function(CAT_TEST_DEFAULT_BUFFER_SIZE + 1);
     ASSERT_NE(nullptr, src);
 
     for (size_t i = 0; i < CAT_TEST_DEFAULT_BUFFER_SIZE; i++) {
@@ -73,8 +73,8 @@ TEST(cat_buffer, realloc_standard_data)
         src_tmp[i] = src[i];
     }
 
-    dst = cat_buffer_allocator.realloc(src, CAT_TEST_DEFAULT_BUFFER_SIZE, CAT_TEST_DEFAULT_BUFFER_SIZE + 1);
-    DEFER(cat_buffer_allocator.free(dst));
+    dst = cat_buffer_allocator.realloc_function(src, CAT_TEST_DEFAULT_BUFFER_SIZE, CAT_TEST_DEFAULT_BUFFER_SIZE + 1);
+    DEFER(cat_buffer_allocator.free_function(dst));
     ASSERT_NE(nullptr, dst);
     ASSERT_NE(src, dst);
 
@@ -90,7 +90,7 @@ TEST(cat_buffer, realloc_standard_less_data)
     /* src will be free, so we need src_tmp */
     char src_tmp[CAT_TEST_DEFAULT_BUFFER_SIZE + 1];
 
-    src = cat_buffer_allocator.alloc(CAT_TEST_DEFAULT_BUFFER_SIZE + 1);
+    src = cat_buffer_allocator.alloc_function(CAT_TEST_DEFAULT_BUFFER_SIZE + 1);
     ASSERT_NE(nullptr, src);
 
     for (size_t i = 0; i < CAT_TEST_DEFAULT_BUFFER_SIZE; i++) {
@@ -98,8 +98,8 @@ TEST(cat_buffer, realloc_standard_less_data)
         src_tmp[i] = src[i];
     }
 
-    dst = cat_buffer_allocator.realloc(src, CAT_TEST_DEFAULT_BUFFER_SIZE, CAT_TEST_DEFAULT_BUFFER_SIZE / 2 + 1);
-    DEFER(cat_buffer_allocator.free(dst));
+    dst = cat_buffer_allocator.realloc_function(src, CAT_TEST_DEFAULT_BUFFER_SIZE, CAT_TEST_DEFAULT_BUFFER_SIZE / 2 + 1);
+    DEFER(cat_buffer_allocator.free_function(dst));
     ASSERT_NE(nullptr, dst);
     ASSERT_NE(src, dst);
 
@@ -112,9 +112,9 @@ TEST(cat_buffer, free_standard)
 {
     char *prt;
 
-    prt = cat_buffer_allocator.alloc(CAT_TEST_DEFAULT_BUFFER_SIZE);
+    prt = cat_buffer_allocator.alloc_function(CAT_TEST_DEFAULT_BUFFER_SIZE);
     ASSERT_NE(nullptr, prt);
-    cat_buffer_allocator.free(prt);
+    cat_buffer_allocator.free_function(prt);
 }
 
 TEST(cat_buffer, module_init)
@@ -466,7 +466,7 @@ TEST(cat_buffer, fetch)
     DEFER(cat_buffer_close(&buffer));
     ASSERT_TRUE(cat_buffer_write(&buffer, 0, data, sizeof(data)));
     prt = cat_buffer_fetch(&buffer);
-    DEFER(cat_buffer_allocator.free(prt));
+    DEFER(cat_buffer_allocator.free_function(prt));
     ASSERT_STREQ(prt, data);
     ASSERT_EQ(empty_buffer, buffer);
 }


### PR DESCRIPTION
Sometimes that malloc, free things will be macro for debug(i.e. MSVCRT debug build).

Things like `somepointer->malloc(somearg)` may be extended like `somepointer->__malloc_dbg(somearg, somehiddenarg)`.

So we renamed it.