### PR TITLE
Allow socket connect to v6-dualstack domains

### DIFF
--- a/include/cat_socket.h
+++ b/include/cat_socket.h
@@ -278,6 +278,20 @@ typedef enum
 
 typedef uint32_t cat_socket_type_t;
 
+/* 0 ~ 8 */
+#define CAT_SOCKET_FLAG_MAP(XX) \
+    XX(NONE, 0)           \
+    XX(ALLOCATED, 1 << 0) \
+
+typedef enum
+{
+#define CAT_SOCKET_FLAG_GEN(name, value) CAT_ENUM_GEN(CAT_SOCKET_FLAG_, name, value)
+    CAT_SOCKET_FLAG_MAP(CAT_SOCKET_FLAG_GEN)
+#undef CAT_SOCKET_FLAG_GEN
+} cat_socket_flag_t;
+
+typedef uint8_t cat_socket_flags_t;
+
 typedef enum
 {
     CAT_SOCKET_INTERNAL_FLAG_NONE = 0,
@@ -293,7 +307,7 @@ typedef uint32_t cat_socket_internal_flags_t;
     XX(RDWR,      CAT_SOCKET_IO_FLAG_READ | CAT_SOCKET_IO_FLAG_WRITE) \
     XX(BIND,      1 << 2 | CAT_SOCKET_IO_FLAG_RDWR) \
     XX(ACCEPT,    1 << 3 | CAT_SOCKET_IO_FLAG_RDWR) \
-    XX(CONNECT,   1 << 4 | CAT_SOCKET_IO_FLAG_RDWR) \
+    XX(CONNECT,   1 << 4 | CAT_SOCKET_IO_FLAG_RDWR)
 
 typedef enum
 {
@@ -420,6 +434,7 @@ struct cat_socket_internal_s
 struct cat_socket_s
 {
     cat_socket_type_t type;
+    cat_socket_flags_t flags;
     cat_socket_internal_t *internal;
 };
 

--- a/src/cat_socket.c
+++ b/src/cat_socket.c
@@ -585,6 +585,13 @@ static cat_always_inline cat_bool_t cat_socket_getaddrbyname(cat_socket_t *socke
     return cat_socket_getaddrbyname_ex(socket, address_info, name, name_length, port, NULL);
 }
 
+static cat_always_inline void cat_socket_on_open(cat_socket_t *socket)
+{
+    if ((socket->type & CAT_SOCKET_TYPE_TCP) == CAT_SOCKET_TYPE_TCP) {
+        cat_socket_tcp_on_open(socket);
+    }
+}
+
 static void cat_socket_tcp_on_open(cat_socket_t *socket)
 {
     cat_socket_internal_t *isocket = socket->internal;
@@ -794,9 +801,7 @@ CAT_API cat_socket_t *cat_socket_create_ex(cat_socket_t *socket, cat_socket_type
         )) {
             isocket->flags |= CAT_SOCKET_INTERNAL_FLAG_CONNECTED;
         }
-        if ((type & CAT_SOCKET_TYPE_TCP) == CAT_SOCKET_TYPE_TCP) {
-            cat_socket_tcp_on_open(socket);
-        }
+        cat_socket_on_open(socket);
     }
 
     return socket;
@@ -1084,9 +1089,7 @@ static cat_bool_t cat_socket__bind(
         return cat_false;
     }
     /* bind done successfully, we can do something here before transfer data */
-    if ((type & CAT_SOCKET_TYPE_TCP) == CAT_SOCKET_TYPE_TCP) {
-        cat_socket_tcp_on_open(socket);
-    }
+    cat_socket_on_open(socket);
     /* clear previous cache (maybe impossible here) */
     if (unlikely(isocket->cache.sockname)) {
         cat_free(isocket->cache.sockname);
@@ -1194,10 +1197,7 @@ CAT_API cat_socket_t *cat_socket_accept_ex(cat_socket_t *server, cat_socket_t *c
             iclient->flags |= CAT_SOCKET_INTERNAL_FLAG_CONNECTED;
             /* TODO: socket_extends() ? */
             memcpy(&iclient->options, &iserver->options, sizeof(iclient->options));
-            /* TODO: socket_on_open() ? */
-            if ((client->type & CAT_SOCKET_TYPE_TCP) == CAT_SOCKET_TYPE_TCP) {
-                cat_socket_tcp_on_open(client);
-            }
+            cat_socket_on_open(client);
             return client;
         }
         if (unlikely(error != CAT_EAGAIN)) {
@@ -1316,9 +1316,7 @@ static cat_bool_t cat_socket__connect(
     /* connect done successfully, we can do something here before transfer data */
     socket->type |= CAT_SOCKET_TYPE_FLAG_CLIENT;
     isocket->flags |= CAT_SOCKET_INTERNAL_FLAG_CONNECTED;
-    if ((type & CAT_SOCKET_TYPE_TCP) == CAT_SOCKET_TYPE_TCP){
-        cat_socket_tcp_on_open(socket);
-    }
+    cat_socket_on_open(socket);
     /* clear previous cache (maybe impossible here) */
     if (unlikely(isocket->cache.peername)) {
         cat_free(isocket->cache.peername);

--- a/src/cat_socket.c
+++ b/src/cat_socket.c
@@ -2716,6 +2716,9 @@ CAT_API cat_bool_t cat_socket_close(cat_socket_t *socket)
         /* we do not update the last error here
          * because the only reason for close failure is
          * it has been closed */
+#ifdef CAT_DEBUG
+        cat_update_last_error(CAT_EBADF, NULL);
+#endif
         return cat_false;
     }
 

--- a/src/cat_socket.c
+++ b/src/cat_socket.c
@@ -1395,7 +1395,7 @@ CAT_API cat_bool_t cat_socket_connect_ex(cat_socket_t *socket, const char *name,
         return cat_false;
     }
     /* Try to connect to all address results until successful */
-    cat_sa_family_t last_af = responses->ai_family;
+    cat_sa_family_t last_af = responses->ai_addr->sa_family;
     cat_bool_t is_initialized = cat_socket_internal_get_fd_fast(isocket) != CAT_SOCKET_INVALID_FD;
     response = responses;
     do {

--- a/src/cat_socket.c
+++ b/src/cat_socket.c
@@ -505,7 +505,7 @@ static cat_timeout_t cat_socket_get_dns_timeout_fast(const cat_socket_t *socket)
 static cat_bool_t cat_socket_getaddrbyname_ex(cat_socket_t *socket, cat_sockaddr_info_t *address_info, const char *name, size_t name_length, int port, cat_bool_t *is_host_name)
 {
     cat_sockaddr_union_t *address = &address_info->address;
-    cat_sa_family_t af = cat_socket_get_af(socket);;
+    cat_sa_family_t af = cat_socket_get_af(socket);
     int error;
 
     /* for failure */
@@ -521,24 +521,17 @@ static cat_bool_t cat_socket_getaddrbyname_ex(cat_socket_t *socket, cat_sockaddr
     if ((socket->type & CAT_SOCKET_TYPE_FLAG_UNSPEC)) {
         if (error == CAT_EINVAL) {
             // try to solve the name
-            struct addrinfo hints;
+            struct addrinfo hints = {0};
             struct addrinfo *response;
-            int sock_type;
-            int protocol;
             cat_bool_t ret;
             if (socket->type & CAT_SOCKET_TYPE_FLAG_STREAM) {
-                sock_type = SOCK_STREAM;
-                protocol = IPPROTO_TCP;
+                hints.ai_socktype = SOCK_STREAM;
             } else if (socket->type & CAT_SOCKET_TYPE_FLAG_DGRAM) {
-                sock_type = SOCK_DGRAM;
-                protocol = IPPROTO_IP;
+                hints.ai_socktype = SOCK_DGRAM;
             } else {
-                sock_type = 0;
-                protocol = IPPROTO_IP;
+                hints.ai_socktype = 0;
             }
             hints.ai_family = af;
-            hints.ai_socktype = sock_type;
-            hints.ai_protocol = protocol;
             hints.ai_flags = 0;
             response = cat_dns_getaddrinfo_ex(name, NULL, &hints, cat_socket_get_dns_timeout_fast(socket));
             if (unlikely(response == NULL)) {
@@ -562,7 +555,7 @@ static cat_bool_t cat_socket_getaddrbyname_ex(cat_socket_t *socket, cat_sockaddr
                     address_info->length = sizeof(cat_sockaddr_in6_t);
                     break;
                 default:
-                    CAT_NEVER_HERE("Must be INET");
+                    CAT_NEVER_HERE("Must be AF_INET/AF_INET6");
             }
         }
         switch (address->common.sa_family) {

--- a/tests/test.h
+++ b/tests/test.h
@@ -56,7 +56,7 @@
 
 #define TEST_LISTEN_HOST                   "localhost"
 #define TEST_LISTEN_IPV4                   "127.0.0.1"
-#define TEST_LISTEN_IPV6                   "::"
+#define TEST_LISTEN_IPV6                   "::1"
 #define TEST_TMP_PATH                      ::testing::CONFIG_TMP_PATH.c_str()
 #ifndef CAT_OS_WIN
 #define TEST_PATH_SEP                      "/"


### PR DESCRIPTION
If a domain has multiple DNS records, `socket_connect_ex` will use the first DNS record rather than try them all.
This patch makes it try all records.