### PR TITLE
OS wait support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ set(cat_sources
     src/cat_buffer.c
     src/cat_fs.c
     src/cat_signal.c
+    src/cat_os_wait.c
     src/cat_async.c
     src/cat_watchdog.c
     src/cat_process.c
@@ -841,6 +842,7 @@ if (LIBCAT_BUILD_TESTS)
         tests/test_cat_buffer.cc
         tests/test_cat_fs.cc
         tests/test_cat_signal.cc
+        tests/test_cat_os_wait.cc
         tests/test_cat_async.cc
         tests/test_cat_watchdog.cc
         tests/test_cat_process.cc

--- a/include/cat_error.h
+++ b/include/cat_error.h
@@ -52,6 +52,8 @@ typedef struct cat_error_s {
     XX(ENOCERT, "Certificate not found") \
     /* certificate verify error */ \
     XX(ECERT, "Certificate verify error") \
+    /* the process specified by pid does not exist */ \
+    XX(ECHILD, "No child processes") \
 
 // workaround for orig_errno()
 #define CAT_ERRNO_EXT_ORIG_MAP(XX) \
@@ -64,6 +66,7 @@ typedef struct cat_error_s {
     XX(ESSL, ECONNRESET) \
     XX(ENOCERT, ECONNRESET) \
     XX(ECERT, ECONNRESET) \
+    XX(ECHILD, ECHILD) \
 
 typedef enum uv_errno_ext_e {
     UV__EEXT = -9764,

--- a/include/cat_module.h
+++ b/include/cat_module.h
@@ -32,6 +32,7 @@
     XX(SIGNAL,    1 << 11) \
     XX(PROCESS,   1 << 12) \
     XX(THREAD,    1 << 13) \
+    XX(OS,        1 << 14) \
     XX(WATCH_DOG, 1 << 17) \
     XX(PROTOCOL,  1 << 18) \
     /* optional (19 ~ 22) */ \

--- a/include/cat_os_wait.h
+++ b/include/cat_os_wait.h
@@ -26,7 +26,13 @@ extern "C" {
 
 #ifdef CAT_OS_UNIX_LIKE
 
+#include <sys/resource.h>
+
 # define CAT_OS_WAIT 1
+
+/* we believe it's always available on nowadays machines,
+ * we can consider checking it only when someone met this problem :) */
+# define CAT_OS_WAIT_HAVE_RUSAGE 1
 
 CAT_API cat_bool_t cat_os_wait_module_init(void);
 CAT_API cat_bool_t cat_os_wait_runtime_init(void);
@@ -36,6 +42,13 @@ CAT_API cat_pid_t cat_os_wait(int *status);
 CAT_API cat_pid_t cat_os_wait_ex(int *status, cat_msec_t timeout);
 CAT_API cat_pid_t cat_os_waitpid(cat_pid_t pid, int *status, int options);
 CAT_API cat_pid_t cat_os_waitpid_ex(cat_pid_t pid, int *status, int options, cat_msec_t timeout);
+
+#ifdef CAT_OS_WAIT_HAVE_RUSAGE
+CAT_API cat_pid_t cat_os_wait3(int *status, int options, struct rusage *rusage);
+CAT_API cat_pid_t cat_os_wait3_ex(int *status, int options, struct rusage *rusage, cat_msec_t timeout);
+CAT_API cat_pid_t cat_os_wait4(cat_pid_t pid, int *status, int options, struct rusage *rusage);
+CAT_API cat_pid_t cat_os_wait4_ex(cat_pid_t pid, int *status, int options, struct rusage *rusage, cat_msec_t timeout);
+#endif /* CAT_OS_WAIT_HAVE_RUSAGE */
 
 #endif
 

--- a/include/cat_os_wait.h
+++ b/include/cat_os_wait.h
@@ -16,57 +16,30 @@
   +--------------------------------------------------------------------------+
  */
 
-#ifndef CAT_API_H
-#define CAT_API_H
+#ifndef CAT_OS_WAIT_H
+#define CAT_OS_WAIT_H
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include "cat.h"
-#include "cat_coroutine.h"
-#include "cat_channel.h"
-#include "cat_sync.h"
-#include "cat_event.h"
-#include "cat_poll.h"
-#include "cat_time.h"
-#include "cat_socket.h"
-#include "cat_dns.h"
-#include "cat_work.h"
-#include "cat_buffer.h"
-#include "cat_fs.h"
-#include "cat_signal.h"
-#include "cat_os_wait.h"
-#include "cat_async.h"
-#include "cat_watchdog.h"
-#include "cat_process.h"
-#include "cat_ssl.h"
 
-typedef enum cat_run_mode_e{
-    CAT_RUN_EASY = 0,
-} cat_run_mode_t;
+#ifdef CAT_OS_UNIX_LIKE
 
-CAT_API cat_bool_t cat_init_all(void);
-CAT_API cat_bool_t cat_shutdown_all(void);
+# define CAT_OS_WAIT 1
 
-CAT_API cat_bool_t cat_module_init_all(void);
-CAT_API cat_bool_t cat_module_shutdown_all(void);
+CAT_API cat_bool_t cat_os_wait_module_init(void);
+CAT_API cat_bool_t cat_os_wait_runtime_init(void);
+CAT_API cat_bool_t cat_os_wait_runtime_shutdown(void);
 
-CAT_API cat_bool_t cat_runtime_init_all(void);
-CAT_API cat_bool_t cat_runtime_shutdown_all(void);
+CAT_API cat_pid_t cat_os_wait(int *status);
+CAT_API cat_pid_t cat_os_wait_ex(int *status, cat_msec_t timeout);
+CAT_API cat_pid_t cat_os_waitpid(cat_pid_t pid, int *status, int options);
+CAT_API cat_pid_t cat_os_waitpid_ex(cat_pid_t pid, int *status, int options, cat_msec_t timeout);
 
-CAT_API cat_bool_t cat_run(cat_run_mode_t run_mode);
-CAT_API cat_bool_t cat_stop(void);
-
-#ifdef CAT_DEBUG
-CAT_API void cat_enable_debug_mode(void);
-#else
-#define cat_enable_debug_mode()
 #endif
-
-CAT_API FILE *cat_get_error_log(void);
-CAT_API void cat_set_error_log(FILE *file);
 
 #ifdef __cplusplus
 }
 #endif
-#endif /* CAT_API_H */
+#endif /* CAT_OS_WAIT_H */

--- a/src/cat_api.c
+++ b/src/cat_api.c
@@ -44,6 +44,9 @@ CAT_API cat_bool_t cat_module_init_all(void)
            cat_ssl_module_init() &&
 #endif
            cat_socket_module_init() &&
+#ifdef CAT_OS_WAIT
+           cat_os_wait_module_init() &&
+#endif
            cat_watchdog_module_init() &&
            cat_true;
 }
@@ -64,6 +67,9 @@ CAT_API cat_bool_t cat_runtime_init_all(void)
            cat_coroutine_runtime_init() &&
            cat_event_runtime_init() &&
            cat_socket_runtime_init() &&
+#ifdef CAT_OS_WAIT
+           cat_os_wait_runtime_init() &&
+#endif
            cat_watchdog_runtime_init() &&
            cat_true;
 }
@@ -73,6 +79,7 @@ CAT_API cat_bool_t cat_runtime_shutdown_all(void)
     cat_bool_t ret = cat_true;
 
     ret = cat_watchdog_runtime_shutdown() && ret;
+    ret = cat_os_wait_runtime_shutdown() && ret;
     ret = cat_event_runtime_shutdown() && ret;
     ret = cat_coroutine_runtime_shutdown() && ret;
     ret = cat_runtime_shutdown() && ret;

--- a/src/cat_api.c
+++ b/src/cat_api.c
@@ -79,7 +79,9 @@ CAT_API cat_bool_t cat_runtime_shutdown_all(void)
     cat_bool_t ret = cat_true;
 
     ret = cat_watchdog_runtime_shutdown() && ret;
+#ifdef CAT_OS_WAIT
     ret = cat_os_wait_runtime_shutdown() && ret;
+#endif
     ret = cat_event_runtime_shutdown() && ret;
     ret = cat_coroutine_runtime_shutdown() && ret;
     ret = cat_runtime_shutdown() && ret;

--- a/src/cat_error.c
+++ b/src/cat_error.c
@@ -139,6 +139,9 @@ CAT_API const char *cat_strerror(cat_errno_t error)
 #ifndef EBADF
 #define EBADF 9
 #endif
+#ifndef ECHILD
+#define ECHILD 10
+#endif
 #ifndef EBUSY
 #define EBUSY 16
 #endif

--- a/src/cat_os_wait.c
+++ b/src/cat_os_wait.c
@@ -291,6 +291,12 @@ static cat_pid_t cat_os__wait(cat_pid_t pid, int *status, int options, void *rus
             cat_free(child_process_state);
             return pid;
         }
+        if (pid > 0) {
+            if (unlikely(!cat_kill(pid, 0) && cat_get_last_error_code() == CAT_ESRCH)) {
+                cat_update_last_error_with_reason(CAT_ECHILD, "OS %s(pid=%d) failed", cat_os_wait_type_name(type), pid);
+                return -1;
+            }
+        }
     } while (cat_os_wait_dispatch() > 0);
 
     cat_os_wait_task_t wait_task;

--- a/src/cat_os_wait.c
+++ b/src/cat_os_wait.c
@@ -130,28 +130,25 @@ static size_t cat_os_wait_dispatch(void)
             break;
         }
         CAT_LOG_DEBUG(OS,
-            "waitpid() = %d, exited=%u, exit_status=%d, if_signaled=%u, termsig=%d, if_stopped=%u, stopsig=%d"
+            "waitpid() = %d, exited=%u, exit_status=%d, if_signaled=%u, termsig=%d, if_stopped=%u, stopsig=%d",
+            pid, WIFEXITED(status), WEXITSTATUS(status), WIFSIGNALED(status), WTERMSIG(status), WIFSTOPPED(status), WSTOPSIG(status)
+        );
 #ifdef CAT_OS_WAIT_HAVE_RUSAGE
-            "\n"
+        CAT_LOG_DEBUG_V3(OS,
             "rusage {\n"
             "    user: %llu sec %llu microsec;\n"
             "    system: %llu sec %llu microsec;\n"
             "    pagefault: %llu;\n"
             "    maximum resident set size: %llu;\n"
-            "}"
-#endif
-            ,
-            pid, WIFEXITED(status), WEXITSTATUS(status), WIFSIGNALED(status), WTERMSIG(status), WIFSTOPPED(status), WSTOPSIG(status)
-#ifdef CAT_OS_WAIT_HAVE_RUSAGE
-            ,
+            "}",
             (unsigned long long) rusage.ru_utime.tv_sec,
             (unsigned long long) rusage.ru_utime.tv_usec,
             (unsigned long long) rusage.ru_stime.tv_sec,
             (unsigned long long) rusage.ru_stime.tv_usec,
             (unsigned long long) rusage.ru_majflt,
             (unsigned long long) rusage.ru_maxrss
-#endif
         );
+#endif
         do {
             /* try to notify waitpid() waiters */
             cat_os_waitpid_task_t *waitpid_task, lookup;

--- a/src/cat_os_wait.c
+++ b/src/cat_os_wait.c
@@ -185,6 +185,8 @@ static cat_always_inline void cat_os_wait_sigchld_watcher_end(void)
 
 static cat_pid_t cat_os__waitpid(cat_pid_t pid, int *status, int options, cat_msec_t timeout, const char *type)
 {
+    /* If pid is 0, the call waits for any child process in the process group of the caller.
+     * but we can not recognize which process is in the same group for now. */
     if (unlikely(pid == 0)) {
         cat_update_last_error(CAT_ENOTSUP, "OS waitpid() with zero pid is not supported yet");
         return -1;

--- a/src/cat_os_wait.c
+++ b/src/cat_os_wait.c
@@ -27,6 +27,8 @@
 
 #include "uv/tree.h"
 
+#include <sys/wait.h>
+
 typedef struct cat_os_wait_task_s {
     cat_queue_t node;
     cat_pid_t pid;

--- a/src/cat_os_wait.c
+++ b/src/cat_os_wait.c
@@ -1,0 +1,313 @@
+/*
+  +--------------------------------------------------------------------------+
+  | libcat                                                                   |
+  +--------------------------------------------------------------------------+
+  | Licensed under the Apache License, Version 2.0 (the "License");          |
+  | you may not use this file except in compliance with the License.         |
+  | You may obtain a copy of the License at                                  |
+  | http://www.apache.org/licenses/LICENSE-2.0                               |
+  | Unless required by applicable law or agreed to in writing, software      |
+  | distributed under the License is distributed on an "AS IS" BASIS,        |
+  | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. |
+  | See the License for the specific language governing permissions and      |
+  | limitations under the License. See accompanying LICENSE file.            |
+  +--------------------------------------------------------------------------+
+  | Author: Twosee <twosee@php.net>                                          |
+  +--------------------------------------------------------------------------+
+ */
+
+
+#include "cat_os_wait.h"
+
+#ifdef CAT_OS_WAIT
+
+#include "cat_signal.h"
+#include "cat_event.h"
+#include "cat_time.h"
+
+#include "uv/tree.h"
+
+typedef struct cat_os_wait_task_s {
+    cat_queue_t node;
+    cat_pid_t pid;
+    int status;
+    cat_coroutine_t *coroutine;
+} cat_os_wait_task_t;
+
+typedef struct cat_os_waitpid_task_s {
+    RB_ENTRY(cat_os_waitpid_task_s) tree_entry;
+    cat_pid_t pid;
+    int status;
+    size_t waiter_count;
+    cat_queue_t waiters;
+} cat_os_waitpid_task_t;
+
+RB_HEAD(cat_os_waitpid_task_tree_s, cat_os_waitpid_task_s);
+
+typedef struct cat_os_child_process_stat_s {
+    RB_ENTRY(cat_os_child_process_stat_s) tree_entry;
+    cat_pid_t pid;
+    int status;
+} cat_os_child_process_stat_t;
+
+RB_HEAD(cat_os_child_process_stat_tree_s, cat_os_child_process_stat_s);
+
+CAT_GLOBALS_STRUCT_BEGIN(cat_os_wait)
+    size_t sigchld_watcher_count;
+    uv_signal_t sigchld_watcher;
+    /* coroutines that hangs on os_wait() */
+    cat_queue_t waiter_list;
+    /* coroutines that hangs on os_waitpid() */
+    struct cat_os_waitpid_task_tree_s waitpid_task_tree;
+    /* those child processes that are recycled */
+    struct cat_os_child_process_stat_tree_s child_process_state_tree;
+CAT_GLOBALS_STRUCT_END(cat_os_wait)
+
+CAT_API CAT_GLOBALS_DECLARE(cat_os_wait)
+
+CAT_GLOBALS_CTOR_DECLARE_SZ(cat_os_wait)
+
+extern CAT_API CAT_GLOBALS_DECLARE(cat_os_wait)
+
+#define CAT_OS_WAIT_G(x) CAT_GLOBALS_GET(cat_os_wait, x)
+
+static int cat_os__waitpid_task_compare(cat_os_waitpid_task_t* t1, cat_os_waitpid_task_t* t2)
+{
+    if (t1->pid < t2->pid) {
+        return -1;
+    }
+    if (t1->pid > t2->pid) {
+        return 1;
+    }
+    return 0;
+}
+
+RB_GENERATE_STATIC(cat_os_waitpid_task_tree_s,
+                   cat_os_waitpid_task_s, tree_entry,
+                   cat_os__waitpid_task_compare);
+
+static int cat_os__child_process_state_compare(cat_os_child_process_stat_t* s1, cat_os_child_process_stat_t* s2)
+{
+    if (s1->pid < s2->pid) {
+        return -1;
+    }
+    if (s1->pid > s2->pid) {
+        return 1;
+    }
+    return 0;
+}
+
+RB_GENERATE_STATIC(cat_os_child_process_stat_tree_s,
+                   cat_os_child_process_stat_s, tree_entry,
+                   cat_os__child_process_state_compare);
+
+static size_t cat_os_waitpid_dispatch(void)
+{
+    size_t new_count = 0;
+
+    CAT_LOG_DEBUG(OS, "waitpid dispatch");
+    while (1) {
+        int status;
+        pid_t pid = waitpid(-1, &status, WNOHANG | WUNTRACED);
+        if (pid <= 0) {
+            break;
+        }
+        CAT_LOG_DEBUG(OS, "waitpid() = %d, exited=%u, exit_status=%d, if_signaled=%u, termsig=%d, if_stopped=%u, stopsig=%d",
+            pid, WIFEXITED(status), WEXITSTATUS(status), WIFSIGNALED(status), WTERMSIG(status), WIFSTOPPED(status), WSTOPSIG(status));
+        do {
+            /* try to notify waitpid() waiters */
+            cat_os_waitpid_task_t *waitpid_task, lookup;
+            lookup.pid = pid;
+            waitpid_task = RB_FIND(cat_os_waitpid_task_tree_s, &CAT_OS_WAIT_G(waitpid_task_tree), &lookup);
+            if (waitpid_task != NULL) {
+                size_t waiter_count = waitpid_task->waiter_count;
+                cat_coroutine_t *coroutine;
+                while ((coroutine = cat_queue_front_data(&waitpid_task->waiters, cat_coroutine_t, waiter.node))) {
+                    CAT_ASSERT(pid == waitpid_task->pid);
+                    waitpid_task->status = status;
+                    CAT_LOG_DEBUG(OS, "Notify a waitpid() waiter");
+                    cat_coroutine_schedule(coroutine, OS, "WaitPid");
+                    /* Ensure that newly joined waiters will not be woken up (pid maybe reused) */
+                    if (--waiter_count == 0) {
+                        break;
+                    }
+                }
+                break;
+            }
+            /* try to notify one wait() waiter */
+            if (!cat_queue_empty(&CAT_OS_WAIT_G(waiter_list))) {
+                cat_os_wait_task_t *wait_task = cat_queue_front_data(&CAT_OS_WAIT_G(waiter_list), cat_os_wait_task_t, node);
+                CAT_ASSERT(wait_task->pid == -1);
+                wait_task->pid = pid;
+                wait_task->status = status;
+                CAT_LOG_DEBUG(OS, "Notify a wait() waiter");
+                cat_coroutine_schedule(wait_task->coroutine, OS, "Wait");
+                break;
+            }
+            /* save status info if nobody cares */
+            CAT_LOG_DEBUG(OS, "Stat info will be saved");
+            cat_os_child_process_stat_t *child_process_state = (cat_os_child_process_stat_t *) cat_malloc(sizeof(*child_process_state));
+            if (unlikely(child_process_state == NULL)) {
+                CAT_SYSCALL_FAILURE(WARNING, OS, "Malloc for OS child process state failed");
+                break;
+            }
+            child_process_state->pid = pid;
+            child_process_state->status = status;
+            RB_INSERT(cat_os_child_process_stat_tree_s, &CAT_OS_WAIT_G(child_process_state_tree), child_process_state);
+            new_count++;
+        } while (0);
+    }
+
+    return new_count;
+}
+
+static void cat_os_wait_sigchld_handler(uv_signal_t* handle, int signum)
+{
+    CAT_ASSERT(signum == CAT_SIGCHLD);
+    CAT_LOG_DEBUG(OS, "SIGCHLD received");
+    (void) cat_os_waitpid_dispatch();
+}
+
+static cat_always_inline void cat_os_wait_sigchld_watcher_start(void)
+{
+    (void) uv_signal_start(&CAT_OS_WAIT_G(sigchld_watcher), cat_os_wait_sigchld_handler, CAT_SIGCHLD);
+    CAT_OS_WAIT_G(sigchld_watcher_count)++;
+}
+
+static cat_always_inline void cat_os_wait_sigchld_watcher_end(void)
+{
+    if (--CAT_OS_WAIT_G(sigchld_watcher_count) == 0) {
+        (void) uv_signal_stop(&CAT_OS_WAIT_G(sigchld_watcher));
+    }
+}
+
+static cat_pid_t cat_os__waitpid(cat_pid_t pid, int *status, int options, cat_msec_t timeout, const char *type)
+{
+    if (unlikely(pid == 0)) {
+        cat_update_last_error(CAT_ENOTSUP, "OS waitpid() with zero pid is not supported yet");
+        return -1;
+    }
+
+    do {
+        cat_os_child_process_stat_t *child_process_state = NULL;
+        if (pid < 0) {
+            cat_os_child_process_stat_t* tmp_child_process_state_iterator;
+            RB_FOREACH_SAFE(child_process_state, cat_os_child_process_stat_tree_s, &CAT_OS_WAIT_G(child_process_state_tree), tmp_child_process_state_iterator) {
+                break;
+            }
+        } else {
+            cat_os_child_process_stat_t lookup;
+            lookup.pid = pid;
+            child_process_state = RB_FIND(cat_os_child_process_stat_tree_s, &CAT_OS_WAIT_G(child_process_state_tree), &lookup);
+        }
+        if (child_process_state != NULL) {
+            RB_REMOVE(cat_os_child_process_stat_tree_s, &CAT_OS_WAIT_G(child_process_state_tree), child_process_state);
+            pid = child_process_state->pid;
+            *status = child_process_state->status;
+            cat_free(child_process_state);
+            return pid;
+        }
+    } while (cat_os_waitpid_dispatch() > 0);
+
+    cat_os_wait_task_t wait_task;
+    cat_os_waitpid_task_t *waitpid_task;
+    if (pid < 0) {
+        wait_task.pid = -1;
+        wait_task.status = 0;
+        wait_task.coroutine = CAT_COROUTINE_G(current);
+        cat_queue_push_back(&CAT_OS_WAIT_G(waiter_list), &wait_task.node);
+    } else {
+        cat_os_waitpid_task_t lookup;
+        lookup.pid = pid;
+        waitpid_task = RB_FIND(cat_os_waitpid_task_tree_s, &CAT_OS_WAIT_G(waitpid_task_tree), &lookup);
+        if (waitpid_task == NULL) {
+            waitpid_task = (cat_os_waitpid_task_t *) cat_malloc(sizeof(*waitpid_task));
+            if (unlikely(waitpid_task == NULL)) {
+                cat_update_last_error_of_syscall("Malloc for waitpid task failed");
+                return -1;
+            }
+            waitpid_task->pid = pid;
+            waitpid_task->status = 0;
+            waitpid_task->waiter_count = 0;
+            cat_queue_init(&waitpid_task->waiters);
+            RB_INSERT(cat_os_waitpid_task_tree_s, &CAT_OS_WAIT_G(waitpid_task_tree), waitpid_task);
+        }
+        waitpid_task->waiter_count++;
+        cat_queue_push_back(&waitpid_task->waiters, &CAT_COROUTINE_G(current)->waiter.node);
+    }
+    
+    cat_bool_t ret = cat_time_wait(timeout);
+
+    if (pid < 0) {
+        pid = wait_task.pid;
+        *status = wait_task.status;
+        cat_queue_remove(&wait_task.node);
+    } else {
+        CAT_ASSERT(pid == waitpid_task->pid);
+        *status = waitpid_task->status;
+        cat_queue_remove(&CAT_COROUTINE_G(current)->waiter.node);
+        if (--waitpid_task->waiter_count == 0) {
+            RB_REMOVE(cat_os_waitpid_task_tree_s, &CAT_OS_WAIT_G(waitpid_task_tree), waitpid_task);
+            cat_free(waitpid_task);
+        }
+    }
+
+    if (unlikely(!ret)) {
+        cat_update_last_error_with_previous("OS %s wait failed", type);
+        return -1;
+    }
+
+    return pid;
+}
+
+static cat_pid_t cat_os__waitpid_wrapper(cat_pid_t pid, int *status, int options, cat_msec_t timeout, const char *type)
+{
+    cat_os_wait_sigchld_watcher_start();
+    pid = cat_os__waitpid(pid, status, options, timeout, type);
+    cat_os_wait_sigchld_watcher_end();
+    return pid;
+}
+
+CAT_API cat_pid_t cat_os_wait(int *status)
+{
+    return cat_os_wait_ex(status, CAT_TIMEOUT_FOREVER);
+}
+
+CAT_API cat_pid_t cat_os_wait_ex(int *status, cat_msec_t timeout)
+{
+    return cat_os__waitpid_wrapper(-1, status, 0, timeout, "wait()");
+}
+
+CAT_API cat_pid_t cat_os_waitpid(cat_pid_t pid, int *status, int options)
+{
+    return cat_os_waitpid_ex(pid, status, options, CAT_TIMEOUT_FOREVER);
+}
+
+CAT_API cat_pid_t cat_os_waitpid_ex(cat_pid_t pid, int *status, int options, cat_msec_t timeout)
+{
+    return cat_os__waitpid_wrapper(pid, status, 0, timeout, "waitpid()");
+}
+
+CAT_API cat_bool_t cat_os_wait_module_init(void)
+{
+    CAT_GLOBALS_REGISTER(cat_os_wait, CAT_GLOBALS_CTOR(cat_os_wait), NULL);
+
+    return cat_true;
+}
+
+CAT_API cat_bool_t cat_os_wait_runtime_init(void)
+{
+    uv_signal_init(cat_event_loop, &CAT_OS_WAIT_G(sigchld_watcher));
+    cat_queue_init(&CAT_OS_WAIT_G(waiter_list));
+
+    return cat_true;
+}
+
+CAT_API cat_bool_t cat_os_wait_runtime_shutdown(void)
+{
+    uv_close((uv_handle_t *) &CAT_OS_WAIT_G(sigchld_watcher), NULL);
+
+    return cat_true;
+}
+
+#endif /* CAT_OS_WAIT */

--- a/tests/test_cat_os_wait.cc
+++ b/tests/test_cat_os_wait.cc
@@ -1,0 +1,96 @@
+/*
+  +--------------------------------------------------------------------------+
+  | libcat                                                                   |
+  +--------------------------------------------------------------------------+
+  | Licensed under the Apache License, Version 2.0 (the "License");          |
+  | you may not use this file except in compliance with the License.         |
+  | You may obtain a copy of the License at                                  |
+  | http://www.apache.org/licenses/LICENSE-2.0                               |
+  | Unless required by applicable law or agreed to in writing, software      |
+  | distributed under the License is distributed on an "AS IS" BASIS,        |
+  | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. |
+  | See the License for the specific language governing permissions and      |
+  | limitations under the License. See accompanying LICENSE file.            |
+  +--------------------------------------------------------------------------+
+  | Author: Twosee <twosee@php.net>                                          |
+  +--------------------------------------------------------------------------+
+ */
+
+#include "test.h"
+
+#ifdef CAT_OS_WAIT
+
+static pid_t new_child_process(int exit_status = 0)
+{
+    pid_t pid = fork();
+    if (pid == 0) {
+        _exit(exit_status);
+    } else if (pid < 0) {
+        CAT_NEVER_HERE("Should never happend");
+    }
+    return pid;
+}
+
+TEST(cat_os_wait, timeout)
+{
+    int status;
+    pid_t w_pid = cat_os_wait_ex(&status, 1);
+    ASSERT_EQ(w_pid, -1);
+    ASSERT_EQ(cat_get_last_error_code(), CAT_ETIMEDOUT);
+}
+
+TEST(cat_os_wait, wait)
+{
+    for (auto exit_status : std::array<int, 2>{ 0, 1 })  {
+        pid_t pid = new_child_process(exit_status);
+
+        int status;
+        pid_t w_pid = cat_os_wait(&status);
+
+        ASSERT_EQ(w_pid, pid);
+        ASSERT_EQ(WIFEXITED(status), 1);
+        ASSERT_EQ(WEXITSTATUS(status), exit_status);
+        ASSERT_EQ(WTERMSIG(status), 0);
+    }
+}
+
+TEST(cat_os_wait, waitpid)
+{
+    for (auto exit_status : std::array<int, 2>{ 0, 1 })  {
+        pid_t pid = new_child_process(exit_status);
+
+        int status;
+        pid_t w_pid = cat_os_waitpid(pid, &status, 0);
+
+        ASSERT_EQ(w_pid, pid);
+        ASSERT_EQ(WIFEXITED(status), 1);
+        ASSERT_EQ(WEXITSTATUS(status), exit_status);
+        ASSERT_EQ(WTERMSIG(status), 0);
+    }
+}
+
+TEST(cat_os_wait, wait_after_sigchld)
+{
+    for (auto type : std::array<int, 2>{ 0, 1 })  {
+        pid_t pid = new_child_process();
+
+        while (cat_kill(pid, 0) == 0) {
+            (void) cat_time_msleep(1);
+        }
+        (void) cat_time_msleep(100);
+
+        int status;
+        pid_t w_pid;
+        if (type == 0) {
+            w_pid = cat_os_wait(&status);
+        } else {
+            w_pid = cat_os_waitpid(pid, &status, 0);
+        }
+        ASSERT_EQ(w_pid, pid);
+        ASSERT_EQ(WIFEXITED(status), 1);
+        ASSERT_EQ(WEXITSTATUS(status), 0);
+        ASSERT_EQ(WTERMSIG(status), 0);
+    }
+}
+
+#endif

--- a/tests/test_cat_os_wait.cc
+++ b/tests/test_cat_os_wait.cc
@@ -24,6 +24,7 @@ static pid_t new_child_process(int exit_status = 0)
 {
     pid_t pid = fork();
     if (pid == 0) {
+        usleep(1000);
         _exit(exit_status);
     } else if (pid < 0) {
         CAT_NEVER_HERE("Should never happend");

--- a/tests/test_cat_os_wait.cc
+++ b/tests/test_cat_os_wait.cc
@@ -68,8 +68,7 @@ TEST(cat_os_wait, wait)
         ASSERT_EQ(WTERMSIG(status), 0);
 #ifdef CAT_OS_WAIT_HAVE_RUSAGE
         if (get_rusage) {
-            ASSERT_GT(rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec, 0);
-            ASSERT_GT(rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec, 0);
+            ASSERT_GT(rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec + rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec, 0);
         }
 #endif
     }
@@ -106,8 +105,7 @@ TEST(cat_os_wait, waitpid)
         ASSERT_EQ(WTERMSIG(status), 0);
 #ifdef CAT_OS_WAIT_HAVE_RUSAGE
         if (get_rusage) {
-            ASSERT_GT(rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec, 0);
-            ASSERT_GT(rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec, 0);
+            ASSERT_GT(rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec + rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec, 0);
         }
 #endif
     }

--- a/tests/test_cat_os_wait.cc
+++ b/tests/test_cat_os_wait.cc
@@ -167,4 +167,17 @@ TEST(cat_os_wait, kill_then_wait)
     ASSERT_EQ(WTERMSIG(status), CAT_SIGTERM);
 }
 
+TEST(cat_os_wait, waitpid_after_wait)
+{
+    pid_t pid = new_child_process();
+    int status;
+    pid_t w_pid = cat_os_wait(&status);
+    ASSERT_EQ(w_pid, pid);
+    ASSERT_EQ(WIFEXITED(status), 1);
+    ASSERT_EQ(WEXITSTATUS(status), 0);
+    w_pid = cat_os_waitpid(pid, &status, 0);
+    ASSERT_EQ(w_pid, -1);
+    ASSERT_EQ(cat_get_last_error_code(), CAT_ECHILD);
+}
+
 #endif


### PR DESCRIPTION
Coroutinify `wait()`, `waitpid()`, `wait3()`, `wait4()` syscalls.