### PR TITLE
[BC] 新的手搓media-type parser

### DIFF
--- a/include/cat_http.h
+++ b/include/cat_http.h
@@ -129,9 +129,7 @@ CAT_API const char *cat_http_status_get_reason(cat_http_status_code_t status);
 #define CAT_HTTP_PARSER_ERRNO_MAP(XX) \
     HTTP_ERRNO_MAP(XX) \
     XX(HPE_MAX + 1, NOMEM, NOMEM) \
-    XX(HPE_MAX + 2, MULTIPART_HEADER, MULTIPART_HEADER) \
-    XX(HPE_MAX + 3, DUPLICATE_CONTENT_TYPE, DUPLICATE_CONTENT_TYPE) \
-    XX(HPE_MAX + 4, MULTIPART_BODY, MULTIPART_BODY) \
+    XX(HPE_MAX + 2, MULTIPART, MULTIPART) \
 
 typedef enum cat_http_parser_standard_errno_e {
 #define CAT_HTTP_PARSER_ERRNO_GEN(code, name, string) CAT_EHP_ ## name = CAT_HTTP_PARSER_STANDARD_ERRNO_START - (code),
@@ -229,16 +227,14 @@ typedef struct cat_http_parser_s {
     cat_http_parser_internal_flags_t internal_flags;
     /* private: handle */
     llhttp_t llhttp;
-    /* private: multipart parser */
-    multipart_parser multipart;
-    /* private: multipart parser header parser index */
-    uint8_t multipart_header_index;
-    /* private: multipart parser state*/
+    /* private: multipart content-type field parser state, also used for mark in-body parsing */
     uint8_t multipart_state;
-    /* private: callback complete state */
-    uint8_t complete_state;
     /* private: multipart parser header parser buffer */
     char multipart_header[12];
+    /* private: multipart content-type value parser state */
+    int header_value_parser_state;
+    /* private: multipart parser */
+    multipart_parser multipart;
     /* private: multipart parser pointer */
     const char *multipart_ptr;
 } cat_http_parser_t;

--- a/src/cat_http.c
+++ b/src/cat_http.c
@@ -39,6 +39,11 @@ CAT_API const char *cat_http_status_get_reason(cat_http_status_code_t status)
     return "UNKNOWN";
 }
 
+#define mt_dbg() do { \
+    CAT_LOG_DEBUG_V3(HTTP, "content_type parser %s:%d state %d char %c", __FILE__, __LINE__, state, *p); \
+} while (0)
+#include "cat_http_content_type.c"
+
 /* http parser definations */
 
 typedef enum cat_http_parser_errno_e {
@@ -48,8 +53,6 @@ typedef enum cat_http_parser_errno_e {
 } cat_http_parser_internal_errno_t;
 
 CAT_STRCASECMP_FAST_FUNCTION(content_type, "content-type", "       \0    ");
-CAT_STRCASECMP_FAST_FUNCTION(multipart_dash, "multipart/", "         \0");
-CAT_STRCASECMP_FAST_FUNCTION(boundary_eq, "boundary=", "        \0");
 
 #define cat_http_parser_throw_error(action, code, fmt, ...) do { \
     parser->internal_flags |= CAT_HTTP_PARSER_INTERNAL_FLAG_HAS_PREVIOUS_ERROR; \
@@ -67,22 +70,14 @@ static void cat_http_parser_update_last_error(cat_http_parser_internal_errno_t e
 
 /* multipart parser things */
 
-typedef enum cat_multipart_state_e {
-    CAT_HTTP_MULTIPART_STATE_UNINIT = 0,
-    CAT_HTTP_MULTIPART_STATE_IN_CONTENT_TYPE,
-    CAT_HTTP_MULTIPART_STATE_TYPE_IS_MULTIPART,
-    CAT_HTTP_MULTIPART_STATE_ALMOST_BOUNDARY,
-    CAT_HTTP_MULTIPART_STATE_BOUNDARY,
-    CAT_HTTP_MULTIPART_STATE_BOUNDARY_START,
-    CAT_HTTP_MULTIPART_STATE_BOUNDARY_COMMON,
-    CAT_HTTP_MULTIPART_STATE_BOUNDARY_QUOTED,
-    CAT_HTTP_MULTIPART_STATE_BOUNDARY_END,
-    CAT_HTTP_MULTIPART_STATE_OUT_CONTENT_TYPE,
-    CAT_HTTP_MULTIPART_STATE_NOT_MULTIPART,
-    CAT_HTTP_MULTIPART_STATE_BOUNDARY_OK,
-    CAT_HTTP_MULTIPART_STATE_IN_BODY,
-    CAT_HTTP_MULTIPART_STATE_BODY_END,
-} cat_multipart_state_t;
+enum cat_multipart_state {
+    CAT_MULTIPART_HEADER_FIELD_STATE_START = 0,
+    CAT_MULTIPART_HEADER_FIELD_STATE_MAYBE_CONTENT_TYPE = sizeof("content-type") - 1,
+    CAT_MULTIPART_HEADER_FIELD_STATE_NOT_CONTENT_TYPE = 252,
+    CAT_MULTIPART_PARSING_VALUE = 253,
+    CAT_MULTIPART_BOUNDARY_OK = 254,
+    CAT_MULTIPART_IN_BODY = 255,
+};
 
 #define CAT_HTTP_MULTIPART_CB_FNAME(name) cat_http_multipart_parser_on_##name
 #define CAT_HTTP_MULTIPART_ON_DATA(name, NAME) \
@@ -125,10 +120,10 @@ CAT_HTTP_MULTIPART_ON_EVENT(part_data_end, MULTIPART_DATA_END)
 static long CAT_HTTP_MULTIPART_CB_FNAME(body_end)(multipart_parser *p)
 {
     cat_http_parser_t* parser = cat_container_of(p, cat_http_parser_t, multipart);
-    CAT_ASSERT(!(parser->events & CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART) || parser->multipart_state == CAT_HTTP_MULTIPART_STATE_IN_BODY);
+    CAT_ASSERT(!(parser->events & CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART) || parser->multipart_state == CAT_MULTIPART_IN_BODY);
     // escape mp parser
     parser->event = CAT_HTTP_PARSER_EVENT_MULTIPART_BODY_END;
-    parser->multipart_state = CAT_HTTP_MULTIPART_STATE_NOT_MULTIPART;
+    parser->multipart_state = CAT_MULTIPART_HEADER_FIELD_STATE_NOT_CONTENT_TYPE;
     CAT_LOG_DEBUG_V2(HTTP, "HTTP multipart parser data on_body_end");
     return MPPE_OK;
 }
@@ -145,333 +140,11 @@ static const multipart_parser_settings cat_http_multipart_parser_settings = {
     CAT_HTTP_MULTIPART_CB_FNAME(body_end),
 };
 
-static cat_always_inline void cat_http_parser_shrink_boundary(cat_http_parser_t *parser)
-{
-    while (parser->multipart.boundary_length > 2 &&
-            (parser->multipart.multipart_boundary[parser->multipart.boundary_length - 1] == '\t' ||
-            parser->multipart.multipart_boundary[parser->multipart.boundary_length - 1] == ' ')) {
-        parser->multipart.boundary_length--;
-    }
-}
-
-/*
-boundary syntax from RFC2046 section 5.1.1
-boundary := 0*69<bchars> bcharsnospace
-bchars := bcharsnospace / " "
-bcharsnospace := DIGIT / ALPHA / "'" / "(" / ")" /
-    "+" / "_" / "," / "-" / "." /
-    "/" / ":" / "=" / "?"
-*/
-static cat_always_inline cat_bool_t cat_http_boundary_char_is_legal(char ch)
-{
-           /* '\'', '(' ')' */ \
-    return ('\'' <= (ch) && (ch) <= ')') ||
-           /* '+', ',', '-', '.', '/', NUM, ':' */
-           ('+' <= (ch) && (ch) <= ':') ||
-           (ch) == '=' ||
-           (ch) == '?' ||
-           ('A' <= (ch) && (ch) <= 'Z') ||
-           (ch) == '_' ||
-           ('a' <= (ch) && (ch) <= 'z') ||
-           (ch) == ' ';
-}
-
-static int cat_http_parser_multipart_parse_content_type(cat_http_parser_t *parser, const char *at, size_t length)
-{
-    // global variables
-    // not parsed inputs length
-    size_t mp_length = length;
-    // buf is [mp_at, mp_endp)
-    const char *mp_endp = at + length;
-#   define mp_at (mp_endp - mp_length)
-#   define mp_state (parser->multipart_state)
-    // local variables
-    size_t mp_size;
-    const char *mp_c;
-    cat_bool_t mp_bool;
-#define DEBUG_STATE(name) do { \
-    CAT_LOG_DEBUG_V3(HTTP, "multipart_parser state at " #name " [%zu] %.*s", mp_length, (int) mp_length, mp_at); \
-} while(0)
-// consume specified length
-#define CONSUME_BUF(len) do { \
-    CAT_ASSERT(parser->multipart_header_index < len); \
-    mp_size = mp_length + (size_t) parser->multipart_header_index; \
-    if (mp_size < len) { \
-        /* not enough, break */ \
-        memcpy(parser->multipart_header + parser->multipart_header_index, mp_at, mp_length); \
-        parser->multipart_header_index = (uint8_t) mp_size; \
-        return CAT_HTTP_PARSER_E_OK; \
-    } \
-    /* copy at to buffer */ \
-    memcpy(parser->multipart_header + parser->multipart_header_index, mp_at, len - parser->multipart_header_index); \
-    mp_length -= len - parser->multipart_header_index; \
-    /* clean multipart_header_index */ \
-    parser->multipart_header_index = 0; \
-} while(0)
-// consume until condition
-#define CONSUME_UNTIL(cond) do { \
-    for (mp_c = mp_at; mp_c < mp_endp; mp_c++) { \
-        if (cond) { \
-            break; \
-        } \
-    } \
-    if (mp_c == mp_endp) { \
-        return CAT_HTTP_PARSER_E_OK; \
-    } \
-    /* update mp_length */ \
-    mp_length = mp_endp - mp_c; \
-} while(0)
-
-    switch (mp_state) {
-        case CAT_HTTP_MULTIPART_STATE_IN_CONTENT_TYPE:
-            // s_start "start"
-            DEBUG_STATE(s_start);
-            CONSUME_BUF(10);
-
-            if (!cat_strcasecmp_fast_multipart_dash(parser->multipart_header)) {
-                // not mp
-                mp_state = CAT_HTTP_MULTIPART_STATE_NOT_MULTIPART;
-                return CAT_HTTP_PARSER_E_OK;
-            }
-            // is mp
-            mp_state = CAT_HTTP_MULTIPART_STATE_TYPE_IS_MULTIPART;
-            /* fallthrough */
-        case CAT_HTTP_MULTIPART_STATE_TYPE_IS_MULTIPART:
-_s_mime_type_end:
-            // s_mime_type_end "mime type end"
-            DEBUG_STATE(s_mime_type_end);
-            // skip to next semicolon
-            CONSUME_UNTIL(*mp_c == ';');
-
-            // consume ';'
-            mp_length--;
-            mp_state = CAT_HTTP_MULTIPART_STATE_ALMOST_BOUNDARY;
-            /* fallthrough */
-        case CAT_HTTP_MULTIPART_STATE_ALMOST_BOUNDARY:
-_s_almost_boundary:
-            // s_almost_boundary "almost 'boundary='"
-            DEBUG_STATE(s_almost_boundary);
-            // skip ows
-            CONSUME_UNTIL(*mp_c != ' ' && *mp_c != '\t');
-
-            mp_state = CAT_HTTP_MULTIPART_STATE_BOUNDARY;
-            /* fallthrough */
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY:
-            // s_boundary "boundary="
-            DEBUG_STATE(s_boundary);
-            CONSUME_BUF(9);
-
-            // if "multipart/dasd; foo; boundary=";
-            //       header buf is ^ -----> ^
-            // so skip to semicolon
-            for (mp_c = parser->multipart_header + 9 - 1; mp_c >= parser->multipart_header; mp_c--) {
-                if (*mp_c == ';') {
-                    break;
-                }
-            }
-            if (mp_c >= parser->multipart_header) {
-                mp_c++; /* ';' */
-                // sizeof new things
-                mp_length += parser->multipart_header + 9 - mp_c;
-                goto _s_almost_boundary;
-            }
-
-            if (!cat_strcasecmp_fast_boundary_eq(parser->multipart_header)) {
-                // not boundary=
-                // roll back to state "mime type end"
-                mp_state = CAT_HTTP_MULTIPART_STATE_TYPE_IS_MULTIPART;
-                goto _s_mime_type_end;
-            }
-            if (parser->multipart.boundary_length != 0) {
-                cat_http_parser_throw_error(return -1, CAT_HTTP_PARSER_E_MULTIPART_HEADER, "Duplicate boundary=");
-            }
-            // is boundary=
-            mp_state = CAT_HTTP_MULTIPART_STATE_BOUNDARY_START;
-            /* fallthrough */
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY_START:
-            // s_boundary_data "boundary data" NOT_ACCEPTABLE
-            DEBUG_STATE(s_boundary_data);
-            if (mp_length == 0) {
-                return CAT_HTTP_PARSER_E_OK;
-            }
-            // reset boundary buf
-            parser->multipart.boundary_length = 2;
-            parser->multipart.multipart_boundary[0] = '-';
-            parser->multipart.multipart_boundary[1] = '-';
-
-            // goto next state
-            mp_state = CAT_HTTP_MULTIPART_STATE_BOUNDARY_COMMON;
-            if (mp_at[0] == '"') {
-                mp_length--;
-                mp_state = CAT_HTTP_MULTIPART_STATE_BOUNDARY_QUOTED;
-                goto _s_boundary_quoted_data;
-            }
-            /* fallthrough */
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY_COMMON:
-            // s_boundary_common_data "boundary common data"
-            DEBUG_STATE(s_boundary_common_data);
-
-            // find parsed size
-            for (mp_c = mp_at; mp_c < mp_endp; mp_c++) {
-                if (!cat_http_boundary_char_is_legal(*mp_c)) {
-                    break;
-                }
-            }
-            mp_size = mp_c - mp_at;
-
-            // should we keep on the state
-            mp_bool = cat_true;
-            if (mp_size + parser->multipart.boundary_length > BOUNDARY_MAX_LEN + 2) {
-                // out of range
-                mp_size = BOUNDARY_MAX_LEN + 2 - parser->multipart.boundary_length;
-            }
-            if (mp_size != mp_length) {
-                // break at middle
-                mp_bool = cat_false;
-            }
-            memcpy(parser->multipart.multipart_boundary + parser->multipart.boundary_length, mp_at, mp_size);
-            parser->multipart.boundary_length += (uint8_t) mp_size;
-            mp_length -= mp_size;
-
-            if (mp_bool) {
-                return CAT_HTTP_PARSER_E_OK;
-            }
-
-            cat_http_parser_shrink_boundary(parser);
-            if (parser->multipart.boundary_length == 0) {
-                cat_http_parser_throw_error(return -1, CAT_HTTP_PARSER_E_MULTIPART_HEADER, "Empty boundary");
-            }
-
-            mp_state = CAT_HTTP_MULTIPART_STATE_BOUNDARY_END;
-            /* fallthrough */
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY_END:
-s_boundary_end:
-            // s_boundary_end "boundary end"
-            DEBUG_STATE(s_boundary_end);
-
-            // consume to semicolon
-            CONSUME_UNTIL((*mp_c) != '\t' && (*mp_c) != ' ');
-
-            if (*mp_c != ';') {
-                cat_http_parser_throw_error(return -1, CAT_HTTP_PARSER_E_MULTIPART_HEADER, "Extra char at boundary end");
-            }
-            length--;
-            mp_state = CAT_HTTP_MULTIPART_STATE_TYPE_IS_MULTIPART;
-            goto _s_mime_type_end;
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY_QUOTED:
-_s_boundary_quoted_data:
-            // s_boundary_quoted_data "boundary quoted data" NOT_ACCEPTABLE
-            DEBUG_STATE(s_boundary_quoted_data);
-
-            // find parsed size
-            for (mp_c = mp_at; mp_c < mp_endp; mp_c++) {
-                if (!cat_http_boundary_char_is_legal(*mp_c)) {
-                    break;
-                }
-            }
-            mp_size = mp_c - mp_at;
-
-            if (mp_size + parser->multipart.boundary_length > BOUNDARY_MAX_LEN + 2) {
-                cat_http_parser_throw_error(return -1, CAT_HTTP_PARSER_E_MULTIPART_HEADER, "Boundary is too long");
-            }
-            // copy to buf
-            memcpy(parser->multipart.multipart_boundary + parser->multipart.boundary_length, mp_at, mp_size);
-            parser->multipart.boundary_length += (uint8_t) mp_size;
-
-            if (mp_length == mp_size) {
-                // not end
-                return CAT_HTTP_PARSER_E_OK;
-            }
-
-            // ending
-            mp_length -= mp_size + 1;
-            if (*mp_c != '"') {
-                cat_http_parser_throw_error(return -1, CAT_HTTP_PARSER_E_MULTIPART_HEADER, "Illegal charactor '%c' in boundary", *mp_c);
-            }
-            if (parser->multipart.multipart_boundary[parser->multipart.boundary_length - 1] == ' ') {
-                cat_http_parser_throw_error(return -1, CAT_HTTP_PARSER_E_MULTIPART_HEADER, "Boundary ends with space");
-            }
-            mp_state = CAT_HTTP_MULTIPART_STATE_BOUNDARY_END;
-            goto s_boundary_end;
-        default:
-            // never here
-            CAT_NEVER_HERE("Unknow state");
-    }
-#undef CONSUME_UNTIL
-#undef CONSUME_BUF
-#undef DEBUG_STATE
-#undef mp_at
-#undef mp_state
-}
-
-static cat_bool_t cat_http_parser_multipart_parser_init(cat_http_parser_t *parser)
-{
-    cat_http_parser_shrink_boundary(parser);
-    if (parser->multipart.boundary_length <= 2) {
-        cat_http_parser_throw_error(return cat_false, CAT_HTTP_PARSER_E_MULTIPART_HEADER, "Empty boundary on EOL");
-    }
-    if (0 != multipart_parser_init(&parser->multipart, NULL, 0, &cat_http_multipart_parser_settings)) {
-        cat_http_parser_throw_error(return cat_false, CAT_HTTP_PARSER_E_MULTIPART_HEADER, "Multipart parser init failed");
-    }
-    CAT_LOG_DEBUG_V3(HTTP, "multipart boundary is [%u] \"%.*s\"",
-        parser->multipart.boundary_length, (int) parser->multipart.boundary_length, parser->multipart.multipart_boundary);
-    parser->multipart_state = CAT_HTTP_MULTIPART_STATE_BOUNDARY_OK;
-
-    return cat_true;
-}
-
-static cat_always_inline cat_bool_t cat_http_parser_multipart_state_solve(cat_http_parser_t *parser)
-{
-    switch (parser->multipart_state) {
-        case CAT_HTTP_MULTIPART_STATE_UNINIT:
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY_OK:
-        case CAT_HTTP_MULTIPART_STATE_NOT_MULTIPART:
-            return cat_true;
-        case CAT_HTTP_MULTIPART_STATE_IN_CONTENT_TYPE:
-        case CAT_HTTP_MULTIPART_STATE_TYPE_IS_MULTIPART:
-        case CAT_HTTP_MULTIPART_STATE_ALMOST_BOUNDARY:
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY:
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY_COMMON:
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY_END:
-            return cat_http_parser_multipart_parser_init(parser);
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY_START:
-        case CAT_HTTP_MULTIPART_STATE_BOUNDARY_QUOTED:
-            cat_http_parser_throw_error(return cat_false, CAT_HTTP_PARSER_E_MULTIPART_HEADER, "Unexpected EOF on parsing Content-Type header");
-        case CAT_HTTP_MULTIPART_STATE_OUT_CONTENT_TYPE:
-            CAT_NEVER_HERE("Never used CAT_HTTP_MULTIPART_STATE_OUT_CONTENT_TYPE");
-            CAT_FALLTHROUGH;
-        case CAT_HTTP_MULTIPART_STATE_IN_BODY:
-        case CAT_HTTP_MULTIPART_STATE_BODY_END:
-            CAT_NEVER_HERE("Should not be body here");
-            CAT_FALLTHROUGH;
-        default:
-            CAT_NEVER_HERE("Unknown state, maybe memory corrupt");
-    }
-}
-
 /* http parser things */
 
 static cat_always_inline cat_http_parser_t *cat_http_parser_get_from_handle(const llhttp_t *llhttp)
 {
     return cat_container_of(llhttp, cat_http_parser_t, llhttp);
-}
-
-typedef enum cat_http_parser_complete_states_e {
-    CAT_HTTP_PARSER_COMPLETE_STATE_HEADER_FIELD_COMPLETE = 1,
-    CAT_HTTP_PARSER_COMPLETE_STATE_HEADER_VALUE_COMPLETE = 2,
-} cat_http_parser_complete_states_t;
-
-static cat_always_inline cat_bool_t cat_http_parser_on_header_value_complete(llhttp_t *llhttp)
-{
-    cat_http_parser_t *parser = cat_http_parser_get_from_handle(llhttp);
-
-    if (parser->complete_state == CAT_HTTP_PARSER_COMPLETE_STATE_HEADER_VALUE_COMPLETE) {
-        // not first called
-        return cat_true;
-    }
-    parser->complete_state = CAT_HTTP_PARSER_COMPLETE_STATE_HEADER_VALUE_COMPLETE;
-
-    return cat_http_parser_multipart_state_solve(parser);
 }
 
 #define CAT_HTTP_PARSER_ON_EVENT_BEGIN(name, NAME) \
@@ -482,12 +155,15 @@ static int cat_http_parser_on_##name(llhttp_t *llhttp) \
     parser->event = CAT_HTTP_PARSER_EVENT_##NAME; \
     \
 
-#define CAT_HTTP_PARSER_ON_EVENT_END() \
+#define _CAT_HTTP_PARSER_ON_EVENT_END() \
     if (((cat_http_parser_event_t) (parser->events & parser->event)) == parser->event) { \
         return CAT_HTTP_PARSER_E_PAUSED; \
     } else { \
         return CAT_HTTP_PARSER_E_OK; \
-    } \
+    }
+
+#define CAT_HTTP_PARSER_ON_EVENT_END() \
+    _CAT_HTTP_PARSER_ON_EVENT_END() \
 }
 
 #define CAT_HTTP_PARSER_ON_EVENT(name, NAME) \
@@ -522,74 +198,91 @@ CAT_HTTP_PARSER_ON_DATA (url,           URL          )
 CAT_HTTP_PARSER_ON_DATA (status,        STATUS       )
 
 CAT_HTTP_PARSER_ON_DATA_BEGIN(header_field, HEADER_FIELD) {
-    if (parser->events & CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART) {
-        if (!cat_http_parser_on_header_value_complete(llhttp)) {
-            return -1;
-        }
-        // copy header into buffer
-        if (length != 0) {
-            size_t index_new = (size_t) parser->multipart_header_index + length;
-            if (index_new < 13) {
-                memcpy(parser->multipart_header + parser->multipart_header_index, at, length);
-                parser->multipart_header_index = (uint8_t) index_new;
-            } else {
-                parser->multipart_header_index = UINT8_MAX;
-            }
-        }
+    if (! (parser->events & CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART)) {
+        _CAT_HTTP_PARSER_ON_EVENT_END();
+    }
+
+    // copy header into buffer
+    if (length == 0) {
+        return CAT_HTTP_PARSER_E_OK;
+    }
+
+    size_t index_new = (size_t) parser->multipart_state + length;
+    if (index_new < 13) {
+        memcpy(parser->multipart_header + parser->multipart_state, at, length);
+        parser->multipart_state = (uint8_t) index_new;
+    } else {
+        parser->multipart_state = CAT_MULTIPART_HEADER_FIELD_STATE_NOT_CONTENT_TYPE;
     }
 } CAT_HTTP_PARSER_ON_EVENT_END()
 
 CAT_HTTP_PARSER_ON_DATA_BEGIN(header_value, HEADER_VALUE) {
-    if (parser->events & CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART) {
-        int error;
-        if (parser->complete_state == CAT_HTTP_PARSER_COMPLETE_STATE_HEADER_VALUE_COMPLETE) {
-            // first called
-            parser->complete_state = CAT_HTTP_PARSER_COMPLETE_STATE_HEADER_FIELD_COMPLETE;
-            if (parser->multipart_header_index == 12 && cat_strcasecmp_fast_content_type(parser->multipart_header)) {
-                if (parser->multipart_state != CAT_HTTP_MULTIPART_STATE_UNINIT) {
-                    cat_http_parser_throw_error(return -1, CAT_HTTP_PARSER_E_DUPLICATE_CONTENT_TYPE, "Duplicate Content-Type header");
-                }
-                CAT_LOG_DEBUG_V3(HTTP, "multipart_parser on_header_field_complete found Content-Type");
-                parser->multipart_state = CAT_HTTP_MULTIPART_STATE_IN_CONTENT_TYPE;
+    if (! (parser->events & CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART)) {
+        _CAT_HTTP_PARSER_ON_EVENT_END();
+    }
+    switch (parser->multipart_state) {
+        case 0 ... 11:
+            // not content-type
+            CAT_FALLTHROUGH;
+        case CAT_MULTIPART_HEADER_FIELD_STATE_NOT_CONTENT_TYPE:
+            // not content-type
+            parser->multipart_state = CAT_MULTIPART_HEADER_FIELD_STATE_START;
+            break;
+        case CAT_MULTIPART_BOUNDARY_OK:
+            // content-type parsed
+            parser->multipart_state = CAT_MULTIPART_HEADER_FIELD_STATE_NOT_CONTENT_TYPE;
+            break;
+        case CAT_MULTIPART_HEADER_FIELD_STATE_MAYBE_CONTENT_TYPE:
+            // maybe content-type
+            if (0 == cat_strcasecmp_fast_content_type(parser->multipart_header)) {
+                parser->multipart_state = CAT_MULTIPART_HEADER_FIELD_STATE_NOT_CONTENT_TYPE;
+                break;
             }
-            parser->multipart_header_index = 0;
-        }
-        if (
-            length > 0 &&
-            parser->multipart_state >= CAT_HTTP_MULTIPART_STATE_IN_CONTENT_TYPE &&
-            parser->multipart_state < CAT_HTTP_MULTIPART_STATE_OUT_CONTENT_TYPE
-        ) {
-            CAT_LOG_DEBUG_V3(HTTP, "multipart_parser Content-Type state %d", parser->multipart_state);
-            error = cat_http_parser_multipart_parse_content_type(parser, at, length);
-            if (CAT_HTTP_PARSER_E_OK != error) {
-                return -1;
-            }
-        }
+            cat_http_parser_multipart_parse_content_type_init(parser);
+            parser->multipart_state = CAT_MULTIPART_PARSING_VALUE;
+            CAT_FALLTHROUGH;
+        case CAT_MULTIPART_PARSING_VALUE:
+            cat_http_parser_multipart_parse_content_type(parser, at, at + length, NULL);
+            break;
+        default:
+        printf("Invalid header field parser state %d\n", parser->multipart_state);
+        CAT_NEVER_HERE("Invalid header field parser state");
     }
 } CAT_HTTP_PARSER_ON_DATA_END()
 
 CAT_HTTP_PARSER_ON_EVENT_BEGIN(headers_complete, HEADERS_COMPLETE) {
     parser->keep_alive = !!llhttp_should_keep_alive(&parser->llhttp);
     parser->content_length = parser->llhttp.content_length;
-    if (parser->events & CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART) {
-        if (!cat_http_parser_on_header_value_complete(llhttp)) {
-            return -1;
-        }
+    if (! (parser->events & CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART)) {
+        _CAT_HTTP_PARSER_ON_EVENT_END();
     }
-    parser->complete_state = 0;
+    // finish parsing media type
+    cat_bool_t ret = cat_http_parser_multipart_parse_content_type(parser, NULL, NULL, NULL);
+    if (!ret) {
+        // bad media-type
+        parser->multipart.boundary_length = 0;
+        return CAT_HTTP_PARSER_E_OK;
+    }
+    if (parser->multipart.boundary_length < 2) {
+        // no boundary, not multipart
+        return CAT_HTTP_PARSER_E_OK;
+    }
+    CAT_LOG_DEBUG_VA_WITH_LEVEL(HTTP, 3, {
+        CAT_LOG_DEBUG_D(HTTP, "multipart boundary is [%d] %.*s",
+            parser->multipart.boundary_length, (int)parser->multipart.boundary_length,
+            parser->multipart.multipart_boundary);
+    });
+    if (0 != multipart_parser_init(&parser->multipart, NULL, 0, &cat_http_multipart_parser_settings)) {
+        CAT_ASSERT(0 && "multipart_parser_init() failed");
+        cat_http_parser_throw_error(return -1, CAT_HTTP_PARSER_E_MULTIPART, "multipart_parser_init() failed");
+    }
 } CAT_HTTP_PARSER_ON_EVENT_END()
 
 CAT_HTTP_PARSER_ON_DATA_BEGIN(body, BODY) {
-    if (parser->events & CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART) {
-        CAT_ASSERT(
-            parser->multipart_state == CAT_HTTP_MULTIPART_STATE_UNINIT ||
-            parser->multipart_state == CAT_HTTP_MULTIPART_STATE_NOT_MULTIPART ||
-            parser->multipart_state == CAT_HTTP_MULTIPART_STATE_BOUNDARY_OK
-        );
-        if (parser->multipart_state == CAT_HTTP_MULTIPART_STATE_BOUNDARY_OK) {
-            return CAT_HTTP_PARSER_E_PAUSED;
-        }
+    if (parser->multipart.boundary_length < 2) {
+        _CAT_HTTP_PARSER_ON_EVENT_END();
     }
+    return CAT_HTTP_PARSER_E_PAUSED;
 } CAT_HTTP_PARSER_ON_EVENT_END()
 
 CAT_HTTP_PARSER_ON_EVENT_BEGIN(chunk_header, CHUNK_HEADER) {
@@ -651,15 +344,13 @@ static cat_always_inline void cat_http_parser__init(cat_http_parser_t *parser)
 {
     parser->llhttp.method = CAT_HTTP_METHOD_UNKNOWN;
     parser->event = CAT_HTTP_PARSER_EVENT_NONE;
-    parser->complete_state = 0;
     parser->data = NULL;
     parser->data_length = 0;
     parser->parsed_length = 0;
     parser->content_length = 0;
     parser->current_chunk_length = 0;
     parser->keep_alive = cat_false;
-    parser->multipart_state = CAT_HTTP_MULTIPART_STATE_UNINIT;
-    parser->multipart_header_index = 0;
+    parser->multipart_state = CAT_MULTIPART_HEADER_FIELD_STATE_START;
     parser->multipart.boundary_length = 0;
     parser->internal_flags = CAT_HTTP_PARSER_INTERNAL_FLAG_NONE;
 }
@@ -755,7 +446,7 @@ static cat_bool_t cat_http_parser_multipart_parser_execute(cat_http_parser_t *pa
         int error_length;
         error_length = multipart_parser_error_msg(&parser->multipart, error_buffer, sizeof(error_buffer));
         CAT_ASSERT((error_length != 0 && error_length <= 4095) && "multipart_parser_error_msg returns bad result");
-        cat_http_parser_throw_error(return cat_false, CAT_HTTP_PARSER_E_MULTIPART_BODY, "Failed to parse multipart body: \"%.*s\"", error_length, error_buffer);
+        cat_http_parser_throw_error(return cat_false, CAT_HTTP_PARSER_E_MULTIPART, "Failed to parse multipart body: \"%.*s\"", error_length, error_buffer);
     }
 
     CAT_LOG_DEBUG_VA_WITH_LEVEL(HTTP, 3, {
@@ -806,7 +497,7 @@ static cat_bool_t cat_http_parser_solve_multipart_body(cat_http_parser_t *parser
     // now parsed length is all body, execute multipart_parser
     ret = cat_http_parser_multipart_parser_execute(parser, mp_body, mp_length);
     parser->parsed_length += http_parsed_length;
-    parser->multipart_state = CAT_HTTP_MULTIPART_STATE_IN_BODY;
+    parser->multipart_state = CAT_MULTIPART_IN_BODY;
 
     return ret;
 }
@@ -818,11 +509,11 @@ CAT_API cat_bool_t cat_http_parser_execute(cat_http_parser_t *parser, const char
 
     parser->previous_event = parser->event;
 
-    if (likely(parser->multipart_state != CAT_HTTP_MULTIPART_STATE_IN_BODY)) {
+    if (likely(parser->multipart_state != CAT_MULTIPART_IN_BODY)) {
         // if not in multipart body
         error = cat_http_parser_llhttp_execute(parser, data, length);
         ret = error == CAT_HTTP_PARSER_E_OK;
-        if (ret && parser->event == CAT_HTTP_PARSER_EVENT_BODY && parser->multipart_state == CAT_HTTP_MULTIPART_STATE_BOUNDARY_OK) {
+        if (ret && parser->event == CAT_HTTP_PARSER_EVENT_BODY && parser->multipart.boundary_length > 2) {
             ret = cat_http_parser_solve_multipart_body(parser);
         }
     } else {
@@ -845,7 +536,7 @@ CAT_API cat_bool_t cat_http_parser_execute(cat_http_parser_t *parser, const char
     }
     if (parser->event == CAT_HTTP_PARSER_EVENT_MESSAGE_COMPLETE) {
         // reset multipart-parser
-        parser->multipart_state = CAT_HTTP_MULTIPART_STATE_UNINIT;
+        parser->multipart_state = CAT_MULTIPART_HEADER_FIELD_STATE_START;
         parser->multipart.boundary_length = 0;
     }
 
@@ -944,7 +635,7 @@ CAT_API const char *cat_http_parser_get_current_pos(const cat_http_parser_t *par
     // bypass llhttp_get_error_pos if in multipart body
     if (
         parser->event & CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART &&
-        parser->multipart_state == CAT_HTTP_MULTIPART_STATE_IN_BODY
+        parser->multipart_state == CAT_MULTIPART_IN_BODY
     ) {
         return parser->multipart_ptr;
     }
@@ -1037,7 +728,7 @@ CAT_API cat_bool_t cat_http_parser_is_upgrade(const cat_http_parser_t *parser)
 
 CAT_API cat_bool_t cat_http_parser_is_multipart(const cat_http_parser_t *parser)
 {
-    return parser->multipart_state >= CAT_HTTP_MULTIPART_STATE_BOUNDARY_OK;
+    return parser->multipart_state >= CAT_MULTIPART_BOUNDARY_OK;
 }
 
 /* module */

--- a/src/cat_http.c
+++ b/src/cat_http.c
@@ -221,7 +221,18 @@ CAT_HTTP_PARSER_ON_DATA_BEGIN(header_value, HEADER_VALUE) {
         _CAT_HTTP_PARSER_ON_EVENT_END();
     }
     switch (parser->multipart_state) {
-        case 0 ... 11:
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        case 10:
+        case 11:
             // not content-type
             CAT_FALLTHROUGH;
         case CAT_MULTIPART_HEADER_FIELD_STATE_NOT_CONTENT_TYPE:

--- a/src/cat_http.c
+++ b/src/cat_http.c
@@ -290,10 +290,9 @@ CAT_HTTP_PARSER_ON_EVENT_BEGIN(headers_complete, HEADERS_COMPLETE) {
 } CAT_HTTP_PARSER_ON_EVENT_END()
 
 CAT_HTTP_PARSER_ON_DATA_BEGIN(body, BODY) {
-    if (parser->multipart.boundary_length < 2) {
-        _CAT_HTTP_PARSER_ON_EVENT_END();
+    if (parser->multipart.boundary_length > 2) {
+        return CAT_HTTP_PARSER_E_PAUSED;
     }
-    return CAT_HTTP_PARSER_E_PAUSED;
 } CAT_HTTP_PARSER_ON_EVENT_END()
 
 CAT_HTTP_PARSER_ON_EVENT_BEGIN(chunk_header, CHUNK_HEADER) {

--- a/src/cat_http_content_type.c
+++ b/src/cat_http_content_type.c
@@ -180,7 +180,7 @@ static cat_always_inline cat_bool_t cat_http_parser_multipart_parse_content_type
             size_t read_len = pe - p > (10 - state + mt_start) ? (10 - state + mt_start) : pe - p;
             // printf("readlen: %d\n", read_len);
             memcpy(&parser->multipart.multipart_boundary[state], p, read_len);
-            state += read_len;
+            state += (int) read_len;
             p += read_len;
 
             if (pe - p == 0) {

--- a/src/cat_http_content_type.c
+++ b/src/cat_http_content_type.c
@@ -1,0 +1,723 @@
+/*
+  +--------------------------------------------------------------------------+
+  | libcat                                                                   |
+  +--------------------------------------------------------------------------+
+  | Licensed under the Apache License, Version 2.0 (the "License");          |
+  | you may not use this file except in compliance with the License.         |
+  | You may obtain a copy of the License at                                  |
+  | http://www.apache.org/licenses/LICENSE-2.0                               |
+  | Unless required by applicable law or agreed to in writing, software      |
+  | distributed under the License is distributed on an "AS IS" BASIS,        |
+  | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. |
+  | See the License for the specific language governing permissions and      |
+  | limitations under the License. See accompanying LICENSE file.            |
+  +--------------------------------------------------------------------------+
+  | Author: Twosee <twosee@php.net>                                          |
+  |         dixyes <dixyes@gmail.com>                                        |
+  +--------------------------------------------------------------------------+
+ */
+
+#ifndef CAT_HTTP_H
+#include "cat_http.h"
+#endif
+
+CAT_STRCASECMP_FAST_FUNCTION(multipart_slash, "multipart/", "         \0");
+
+enum media_type_state {
+    mt_error = 0,
+    mt_start = 1,
+    /* 1 - 10 in_multipart */
+    mt_maybe_subtype = mt_start+10,
+    mt_subtype,
+    mt_parameter_ows1_acceptable,
+    mt_parameter_ows1,
+    mt_parameter_ows2,
+    mt_parameter_name,
+    mt_parameter_value,
+    mt_parameter_literal_value_acceptable,
+    mt_parameter_quoted_value,
+    mt_quoted_pair,
+    mt_boundary_eq_o,
+    mt_boundary_eq_u,
+    mt_boundary_eq_n,
+    mt_boundary_eq_d,
+    mt_boundary_eq_a,
+    mt_boundary_eq_r,
+    mt_boundary_eq_y,
+    mt_boundary_eq_eq,
+    mt_boundary_value,
+    mt_boundary_literal_value_acceptable,
+    mt_boundary_quoted_value,
+    mt_boundary_quoted_value_unacceptable,
+    mt_boundary_quoted_pair,
+};
+
+static cat_always_inline void cat_http_parser_multipart_parse_content_type_init(cat_http_parser_t *parser) {
+    parser->header_value_parser_state = mt_start;
+    parser->multipart.boundary_length = 0;
+    parser->multipart.multipart_boundary[0] = 0;
+}
+
+static cat_always_inline cat_bool_t cat_http_parser_multipart_parse_content_type(
+    cat_http_parser_t *parser,
+    const char *p,
+    const char *pe,
+    const char *eof
+) {
+    if (p == eof) {
+        goto next;
+    }
+
+#define state parser->header_value_parser_state
+#define tchar_cases \
+    case '!': CAT_FALLTHROUGH; \
+    case '#': CAT_FALLTHROUGH; \
+    case '$': CAT_FALLTHROUGH; \
+    case '%': CAT_FALLTHROUGH; \
+    case '&': CAT_FALLTHROUGH; \
+    case '\'': CAT_FALLTHROUGH; \
+    case '*': CAT_FALLTHROUGH; \
+    case '+': CAT_FALLTHROUGH; \
+    case '-': CAT_FALLTHROUGH; \
+    case '.': CAT_FALLTHROUGH; \
+    case '^': CAT_FALLTHROUGH; \
+    case '_': CAT_FALLTHROUGH; \
+    case '`': CAT_FALLTHROUGH; \
+    case '|': CAT_FALLTHROUGH; \
+    case '~':
+#define digit_cases \
+    case '0': CAT_FALLTHROUGH; \
+    case '1': CAT_FALLTHROUGH; \
+    case '2': CAT_FALLTHROUGH; \
+    case '3': CAT_FALLTHROUGH; \
+    case '4': CAT_FALLTHROUGH; \
+    case '5': CAT_FALLTHROUGH; \
+    case '6': CAT_FALLTHROUGH; \
+    case '7': CAT_FALLTHROUGH; \
+    case '8': CAT_FALLTHROUGH; \
+    case '9':
+#define alpha_cases \
+    case 'a': CAT_FALLTHROUGH; \
+    case 'b': CAT_FALLTHROUGH; \
+    case 'c': CAT_FALLTHROUGH; \
+    case 'd': CAT_FALLTHROUGH; \
+    case 'e': CAT_FALLTHROUGH; \
+    case 'f': CAT_FALLTHROUGH; \
+    case 'g': CAT_FALLTHROUGH; \
+    case 'h': CAT_FALLTHROUGH; \
+    case 'i': CAT_FALLTHROUGH; \
+    case 'j': CAT_FALLTHROUGH; \
+    case 'k': CAT_FALLTHROUGH; \
+    case 'l': CAT_FALLTHROUGH; \
+    case 'm': CAT_FALLTHROUGH; \
+    case 'n': CAT_FALLTHROUGH; \
+    case 'o': CAT_FALLTHROUGH; \
+    case 'p': CAT_FALLTHROUGH; \
+    case 'q': CAT_FALLTHROUGH; \
+    case 'r': CAT_FALLTHROUGH; \
+    case 's': CAT_FALLTHROUGH; \
+    case 't': CAT_FALLTHROUGH; \
+    case 'u': CAT_FALLTHROUGH; \
+    case 'v': CAT_FALLTHROUGH; \
+    case 'w': CAT_FALLTHROUGH; \
+    case 'x': CAT_FALLTHROUGH; \
+    case 'y': CAT_FALLTHROUGH; \
+    case 'z': CAT_FALLTHROUGH; \
+    case 'A': CAT_FALLTHROUGH; \
+    case 'B': CAT_FALLTHROUGH; \
+    case 'C': CAT_FALLTHROUGH; \
+    case 'D': CAT_FALLTHROUGH; \
+    case 'E': CAT_FALLTHROUGH; \
+    case 'F': CAT_FALLTHROUGH; \
+    case 'G': CAT_FALLTHROUGH; \
+    case 'H': CAT_FALLTHROUGH; \
+    case 'I': CAT_FALLTHROUGH; \
+    case 'J': CAT_FALLTHROUGH; \
+    case 'K': CAT_FALLTHROUGH; \
+    case 'L': CAT_FALLTHROUGH; \
+    case 'M': CAT_FALLTHROUGH; \
+    case 'N': CAT_FALLTHROUGH; \
+    case 'O': CAT_FALLTHROUGH; \
+    case 'P': CAT_FALLTHROUGH; \
+    case 'Q': CAT_FALLTHROUGH; \
+    case 'R': CAT_FALLTHROUGH; \
+    case 'S': CAT_FALLTHROUGH; \
+    case 'T': CAT_FALLTHROUGH; \
+    case 'U': CAT_FALLTHROUGH; \
+    case 'V': CAT_FALLTHROUGH; \
+    case 'W': CAT_FALLTHROUGH; \
+    case 'X': CAT_FALLTHROUGH; \
+    case 'Y': CAT_FALLTHROUGH; \
+    case 'Z':
+#define token_cases \
+    tchar_cases CAT_FALLTHROUGH; \
+    digit_cases CAT_FALLTHROUGH; \
+    alpha_cases
+#ifndef mt_dbg
+# define mt_dbg() do { \
+    printf("state %d *p='%c'\n", state, *p); \
+} while (0)
+#endif
+
+    
+    // cat_bool_t acceptable = cat_false;
+    switch (state)
+    {
+        case mt_start: CAT_FALLTHROUGH;
+        case mt_start + 1: CAT_FALLTHROUGH;
+        case mt_start + 2: CAT_FALLTHROUGH;
+        case mt_start + 3: CAT_FALLTHROUGH;
+        case mt_start + 4: CAT_FALLTHROUGH;
+        case mt_start + 5: CAT_FALLTHROUGH;
+        case mt_start + 6: CAT_FALLTHROUGH;
+        case mt_start + 7: CAT_FALLTHROUGH;
+        case mt_start + 8: CAT_FALLTHROUGH;
+        case mt_start + 9:
+        mt_dbg();
+            /*
+            'multipart/' => continue to check
+            */
+            size_t read_len = pe - p > (10 - state + mt_start) ? (10 - state + mt_start) : pe - p;
+            // printf("readlen: %d\n", read_len);
+            memcpy(&parser->multipart.multipart_boundary[state], p, read_len);
+            state += read_len;
+            p += read_len;
+
+            if (pe - p == 0) {
+                goto next;
+            }
+            if (unlikely(pe < p)) {
+                CAT_ASSERT(0 && "logical bug");
+                goto error;
+            }
+            CAT_FALLTHROUGH;
+        case mt_maybe_subtype:
+        mt_dbg();
+            if (!cat_strcasecmp_fast_multipart_slash(&parser->multipart.multipart_boundary[1])) {
+                /* not multipart */
+                goto error;
+            }
+            /*
+            tchar   = "!" | "#" | "$" | "%" | "&" | "'" | "*" | "+" | "-" | "." | "^" | "_" | "`" | "|" | "~" | [0-9a-zA-Z];
+            token   = tchar +;
+            subtype = token;
+
+            subtype => mt_subtype
+            */
+            switch (*p) {
+                token_cases
+                    p++;
+                    state = mt_subtype;
+                    break;
+                default:
+                    goto error;
+            }
+            CAT_FALLTHROUGH;
+        case mt_subtype:
+        mt_dbg();
+            /*
+            ows = [ \t]*;
+
+            subtype => self
+            ows => mt_parameter_ows1
+            ';' => mt_parameter_ows2
+            */
+            for (; p < pe; p++) {
+                switch (*p) {
+                    case ';':
+                        p++;
+                        state = mt_parameter_ows2;
+                        goto mt_parameter_ows2;
+                    case ' ': CAT_FALLTHROUGH;
+                    case '\t':
+                        state = mt_parameter_ows1_acceptable;
+                        goto mt_parameter_ows1_acceptable;
+                    token_cases
+                        /* do nothing */
+                        break;
+                    default:
+                        goto error;
+                }
+            }
+            goto next;
+        case mt_parameter_ows1_acceptable:
+mt_parameter_ows1_acceptable:
+        mt_dbg();
+            p++;
+            // printf("%p %p\n", p, pe);
+            if (p == pe) {
+                goto next;
+            }
+            if (unlikely(p > pe)) {
+                CAT_ASSERT(0 && "logical bug");
+                goto error;
+            }
+            state = mt_parameter_ows1;
+            CAT_FALLTHROUGH;
+        case mt_parameter_ows1:
+mt_parameter_ows1:
+        mt_dbg();
+            /*
+            ows => self
+            ';' => mt_parameter_ows2
+            */
+            for (; p < pe; p++) {
+                switch (*p) {
+                    case ' ': CAT_FALLTHROUGH;
+                    case '\t':
+                        /* do nothing */
+                        break;
+                    case ';':
+                        p++;
+                        state = mt_parameter_ows2;
+                        goto mt_parameter_ows2;
+                    default:
+                        goto error;
+                }
+            }
+            goto next;
+        case mt_parameter_ows2:
+mt_parameter_ows2:
+        mt_dbg();
+            /*
+            parameter_name  = token;
+
+            ows => self
+            parameter_name => mt_parameter_name
+            [bB] => mt_boundary_eq_o
+            */
+            for (; p < pe; p++) {
+                switch (*p) {
+                    case ' ': CAT_FALLTHROUGH;
+                    case '\t':
+                        /* do nothing */
+                        break;
+                    token_cases
+                        if (likely(*p == 'b' || *p == 'B')) {
+                            p++;
+                            state = mt_boundary_eq_o;
+                            goto mt_boundary_eq_o;
+                        }
+                        state = mt_parameter_name;
+                        goto mt_parameter_name;
+                    default:
+                        goto error;
+                }
+            }
+            goto next;
+        case mt_parameter_name:
+mt_parameter_name:
+        mt_dbg();
+            /*
+            parameter_name => self
+            '=' => mt_parameter_value
+            */
+            for (; p < pe; p++) {
+                switch (*p) {
+                    token_cases
+                        /* do nothing */
+                        break;
+                    case '=':
+                        p++;
+                        state = mt_parameter_value;
+                        goto mt_parameter_value;
+                    default:
+                        goto error;
+                }
+            }
+            goto next;
+        case mt_parameter_value:
+mt_parameter_value:
+        mt_dbg();
+            /*
+            obs_text = [\x80-\xff];
+            vchar    = [\x1f-\x7e];
+
+            qdtext         = [\t] | [ ] | [\x21] | [\x23-\x5b] | [\x5d-\x7e] | obs_text;
+            quoted_pair    = "\\" ( [\t] | [ ] | vchar | obs_text );
+            quoted_string  = ["] ( qdtext | quoted_pair )* ["];
+
+            parameter_value = (token | quoted_string)*;
+
+            parameter_value => mt_parameter_literal_value
+            ["] => mt_parameter_quoted_value
+            ows => mt_parameter_ows1
+            [;] => mt_parameter_ows2
+            */
+            switch (*p) {
+                token_cases
+                    state = mt_parameter_literal_value_acceptable;
+                    goto mt_parameter_literal_value_acceptable;
+                case '"':
+                    p++;
+                    state = mt_parameter_quoted_value;
+                    goto mt_parameter_quoted_value;
+                case ' ': CAT_FALLTHROUGH;
+                case '\t':
+                    state = mt_parameter_ows1;
+                    goto mt_parameter_ows1;
+                case ';':
+                    p++;
+                    state = mt_parameter_ows2;
+                    goto mt_parameter_ows2;
+                default:
+                    goto error;
+            }
+            goto next;
+        case mt_parameter_quoted_value:
+mt_parameter_quoted_value:
+        mt_dbg();
+            /*
+            qdtext => self
+            "\\" => mt_quoted_pair
+            ["] => mt_parameter_ows1
+            */
+            for (; p < pe; p++) {
+                if (
+                    *p == '\t' || *p == ' ' || *p == '\x21' ||
+                    ('\x23' <= *p && *p <= '\x5b') ||
+                    ('\x5d' <= *p && *p <= '\x7e') ||
+                    (/* '\x80' <= *p && */ *p <= '\xff')
+                ) {
+                    /* qdtext */
+                    /* do nothing */
+                } else if (*p == '\\') {
+                    p++;
+                    state = mt_quoted_pair;
+                    goto mt_quoted_pair;
+                } else if (*p == '"') {
+                    state = mt_parameter_ows1_acceptable;
+                    goto mt_parameter_ows1_acceptable;
+                } else {
+                    goto error;
+                }
+            }
+            goto next;
+        case mt_quoted_pair:
+mt_quoted_pair:
+        mt_dbg();
+            /*
+            [ \t\x1f-\x7e\x80-\xff] => mt_parameter_quoted_value
+            */
+            if (
+                *p == ' ' || *p == '\t' ||
+                ('\x1f' <= *p && *p <= '\x7e') ||
+                (/* '\x80' <= *p && */ *p <= '\xff')
+            ) {
+                p++;
+                state = mt_parameter_quoted_value;
+                goto mt_parameter_quoted_value;
+            }
+            goto error;
+        case mt_parameter_literal_value_acceptable:
+mt_parameter_literal_value_acceptable:
+        mt_dbg();
+            /*
+            parameter_value => self
+            ows => mt_parameter_ows1
+            [;] => mt_parameter_ows2
+            */
+            for (; p < pe; p++) {
+                switch (*p) {
+                    token_cases
+                        /* do nothing */
+                        break;
+                    case ' ': CAT_FALLTHROUGH;
+                    case '\t':
+                        state = mt_parameter_ows1;
+                        goto mt_parameter_ows1;
+                    case ';':
+                        p++;
+                        state = mt_parameter_ows2;
+                        goto mt_parameter_ows2;
+                    default:
+                        goto error;
+                }
+            }
+            goto next;
+        case mt_boundary_eq_o: CAT_FALLTHROUGH;
+        case mt_boundary_eq_u: CAT_FALLTHROUGH;
+        case mt_boundary_eq_n: CAT_FALLTHROUGH;
+        case mt_boundary_eq_d: CAT_FALLTHROUGH;
+        case mt_boundary_eq_a: CAT_FALLTHROUGH;
+        case mt_boundary_eq_r: CAT_FALLTHROUGH;
+        case mt_boundary_eq_y:
+mt_boundary_eq_o:
+        mt_dbg();
+            for (; p < pe; p++) {
+                switch (*p) {
+                    digit_cases CAT_FALLTHROUGH;
+                    tchar_cases
+                        state = mt_parameter_name;
+                        goto mt_parameter_name;
+                    alpha_cases
+                        // printf("%c vs %c\n", (0x20 | (*p)), "oundary"[state - mt_boundary_eq_o]);
+                        if (likely(
+                            (0x20 | (*p)) /* tolower */
+                            == "oundary"[state - mt_boundary_eq_o]
+                        )) {
+                            state++;
+                            break;
+                        }
+                        state = mt_parameter_name;
+                        goto mt_parameter_name;
+                    case '=':
+                        if (state != mt_boundary_eq_eq) {
+                            goto error;
+                        }
+                        goto mt_boundary_eq_eq;
+                    default:
+                        goto error;
+                }
+            }
+            goto next;
+        case mt_boundary_eq_eq:
+mt_boundary_eq_eq:
+        mt_dbg();
+            if (*p == '=') {
+                // printf("parser->multipart.boundary_length = %d\n", parser->multipart.boundary_length);
+                if (parser->multipart.boundary_length != 0) {
+                    goto error;
+                }
+                parser->multipart.boundary_length = 2;
+                parser->multipart.multipart_boundary[0] = '-';
+                parser->multipart.multipart_boundary[1] = '-';
+
+                p++;
+                state = mt_boundary_value;
+                goto mt_boundary_value;
+            } else {
+                state = mt_parameter_name;
+                goto mt_parameter_name;
+            }
+        case mt_boundary_value:
+mt_boundary_value:
+        mt_dbg();
+            /*
+            bcharsnospace = digit | alpha | "'" | "(" | ")" |
+                        "+" | "_" | "," | "-" | "." |
+                        "/" | ":" | "=" | "?";
+            bchars = bcharsnospace | " ";
+            boundary = bchars{0,69} bcharsnospace;
+
+            ["] => mt_boundary_quoted_value
+            bchars & token => mt_boundary_literal_value
+            */
+            switch (*p) {
+                case '"':
+                    p++;
+                    state = mt_boundary_quoted_value;
+                    goto mt_boundary_quoted_value;
+                digit_cases CAT_FALLTHROUGH;
+                alpha_cases CAT_FALLTHROUGH;
+                case '\'': CAT_FALLTHROUGH;
+                case '+': CAT_FALLTHROUGH;
+                case '_': CAT_FALLTHROUGH;
+                case '-': CAT_FALLTHROUGH;
+                case '.':
+                    state = mt_boundary_literal_value_acceptable;
+                    goto mt_boundary_literal_value_acceptable;
+                default:
+                    goto error;
+            }
+            goto next;
+        case mt_boundary_quoted_value:
+mt_boundary_quoted_value:
+        mt_dbg();
+            /*
+            RFC 2046 5.1.1
+
+            Thus, a typical "multipart" Content-Type header
+            field might look like this:
+
+                Content-Type: multipart/mixed; boundary=gc0p4Jq0M2Yt08j34c0p
+
+            But the following is not valid:
+
+                Content-Type: multipart/mixed; boundary=gc0pJq0M:08jU534c0p
+
+            (because of the colon) and must instead be represented as
+
+                Content-Type: multipart/mixed; boundary="gc0pJq0M:08jU534c0p"
+
+            [^ \t] => mt_boundary_quoted_value_unacceptable
+            (bchars & qdtext (actually bchars)) & [^ \t] => self
+            "\\" => mt_boundary_quoted_pair
+            ["] => mt_parameter_ows1
+            */
+            for (; p < pe; p++) {
+                switch (*p) {
+                    case ' ': CAT_FALLTHROUGH;
+                    case '\t':
+                        state = mt_boundary_quoted_value_unacceptable;
+                        goto mt_boundary_quoted_value_unacceptable;
+                    digit_cases CAT_FALLTHROUGH;
+                    alpha_cases CAT_FALLTHROUGH;
+                    case '\'': CAT_FALLTHROUGH;
+                    case '(': CAT_FALLTHROUGH;
+                    case ')': CAT_FALLTHROUGH;
+                    case '+': CAT_FALLTHROUGH;
+                    case '_': CAT_FALLTHROUGH;
+                    case ',': CAT_FALLTHROUGH;
+                    case '-': CAT_FALLTHROUGH;
+                    case '.': CAT_FALLTHROUGH;
+                    case '/': CAT_FALLTHROUGH;
+                    case ':': CAT_FALLTHROUGH;
+                    case '=': CAT_FALLTHROUGH;
+                    case '?':
+                        /* bchars */
+                        /* record the boundary char */
+                        if (parser->multipart.boundary_length >= 72 /* strlen('--' boundary) */) {
+                            goto error;
+                        }
+                        parser->multipart.multipart_boundary[parser->multipart.boundary_length++] = *p;
+                        break;
+                    case '\\':
+                        p++;
+                        state = mt_boundary_quoted_pair;
+                        goto mt_boundary_quoted_pair;
+                    case '"':
+                        state = mt_parameter_ows1_acceptable;
+                        goto mt_parameter_ows1_acceptable;
+                }
+            }
+            goto next;
+        case mt_boundary_quoted_value_unacceptable:
+mt_boundary_quoted_value_unacceptable:
+            for (; p < pe; p++) {
+                switch (*p) {
+                    digit_cases CAT_FALLTHROUGH;
+                    alpha_cases CAT_FALLTHROUGH;
+                    case '\'': CAT_FALLTHROUGH;
+                    case '(': CAT_FALLTHROUGH;
+                    case ')': CAT_FALLTHROUGH;
+                    case '+': CAT_FALLTHROUGH;
+                    case '_': CAT_FALLTHROUGH;
+                    case ',': CAT_FALLTHROUGH;
+                    case '-': CAT_FALLTHROUGH;
+                    case '.': CAT_FALLTHROUGH;
+                    case '/': CAT_FALLTHROUGH;
+                    case ':': CAT_FALLTHROUGH;
+                    case '=': CAT_FALLTHROUGH;
+                    case '?':
+                        state = mt_boundary_quoted_value;
+                        goto mt_boundary_quoted_value;
+                    case ' ': CAT_FALLTHROUGH;
+                    case '\t':
+                        /* bchars */
+                        /* record the boundary char */
+                        if (parser->multipart.boundary_length >= 72 /* strlen('--' boundary) */) {
+                            goto error;
+                        }
+                        parser->multipart.multipart_boundary[parser->multipart.boundary_length++] = *p;
+                        break;
+                    case '\\':
+                        p++;
+                        state = mt_boundary_quoted_pair;
+                        goto mt_boundary_quoted_pair;
+                    case '"':
+                        state = mt_parameter_ows1;
+                        goto mt_parameter_ows1;
+                }
+            }
+            goto next;
+
+        case mt_boundary_quoted_pair:
+mt_boundary_quoted_pair:
+        mt_dbg();
+            /*
+            RFC 9110 5.6.4
+
+            that process the value of a quoted-string MUST handle a quoted-pair
+            as if it were replaced by the octet following the backslash.
+
+            ([ \t] | vchar | obs_text) & bchars => mt_boundary_quoted_value
+            */
+            switch (*p) {
+                case ' ': CAT_FALLTHROUGH;
+                case '\t': CAT_FALLTHROUGH;
+                digit_cases CAT_FALLTHROUGH;
+                alpha_cases CAT_FALLTHROUGH;
+                case '\'': CAT_FALLTHROUGH;
+                case '(': CAT_FALLTHROUGH;
+                case ')': CAT_FALLTHROUGH;
+                case '+': CAT_FALLTHROUGH;
+                case '_': CAT_FALLTHROUGH;
+                case ',': CAT_FALLTHROUGH;
+                case '-': CAT_FALLTHROUGH;
+                case '.': CAT_FALLTHROUGH;
+                case '/': CAT_FALLTHROUGH;
+                case ':': CAT_FALLTHROUGH;
+                case '=': CAT_FALLTHROUGH;
+                case '?':
+                    state = mt_boundary_quoted_value;
+                    goto mt_boundary_quoted_value;
+                default:
+                    goto error;
+            }
+            CAT_NEVER_HERE("impossible char");
+        case mt_boundary_literal_value_acceptable:
+mt_boundary_literal_value_acceptable:
+        mt_dbg();
+            /*
+            bchars & token => self
+            ows => mt_parameter_ows1
+            [;] => mt_parameter_ows2
+            */
+            for (; p < pe; p++) {
+                switch (*p) {
+                    digit_cases CAT_FALLTHROUGH;
+                    alpha_cases CAT_FALLTHROUGH;
+                    case '\'': CAT_FALLTHROUGH;
+                    case '+': CAT_FALLTHROUGH;
+                    case '_': CAT_FALLTHROUGH;
+                    case '-': CAT_FALLTHROUGH;
+                    case '.':
+                        /* bchars */
+                        /* record the boundary char */
+                        if (parser->multipart.boundary_length >= 72 /* strlen('--' boundary) */) {
+                            goto error;
+                        }
+                        parser->multipart.multipart_boundary[parser->multipart.boundary_length++] = *p;
+                        break;
+                    case ' ': CAT_FALLTHROUGH;
+                    case '\t':
+                        state = mt_parameter_ows1;
+                        goto mt_parameter_ows1;
+                    case ';':
+                        p++;
+                        state = mt_parameter_ows2;
+                        goto mt_parameter_ows2;
+                    default:
+                        goto error;
+                }
+            }
+            goto next;
+        case mt_error:
+error:
+        //printf("error state %d *p='%c'\n", state, *p);
+            parser->header_value_parser_state = mt_error;
+            return cat_false;
+            break;
+        default:
+            CAT_NEVER_HERE("impossible state");
+            break;
+    }
+next:
+
+    switch(state) {
+        case mt_parameter_ows1_acceptable: CAT_FALLTHROUGH;
+        case mt_parameter_literal_value_acceptable: CAT_FALLTHROUGH;
+        case mt_boundary_literal_value_acceptable:
+            // acceptable = cat_true;
+            return cat_true;
+    }
+    return cat_false;
+
+#undef state
+#undef tchar_cases
+#undef digit_cases
+#undef alpha_cases
+#undef token_cases
+#undef mt_dbg
+}

--- a/src/cat_http_content_type.c
+++ b/src/cat_http_content_type.c
@@ -655,7 +655,7 @@ mt_boundary_quoted_pair:
                 default:
                     goto error;
             }
-            CAT_NEVER_HERE("impossible char");
+            // never here
         case mt_boundary_literal_value_acceptable:
 mt_boundary_literal_value_acceptable:
         mt_dbg();

--- a/src/cat_http_content_type.c
+++ b/src/cat_http_content_type.c
@@ -463,7 +463,9 @@ mt_boundary_eq_o:
                         goto mt_parameter_name;
                     case '=':
                         if (state != mt_boundary_eq_eq) {
-                            goto error;
+                            p++;
+                            state = mt_parameter_value;
+                            goto mt_parameter_value;
                         }
                         goto mt_boundary_eq_eq;
                     default:

--- a/tests/test_cat_http.cc
+++ b/tests/test_cat_http.cc
@@ -579,7 +579,7 @@ static const cat_const_string_t multipart_req_heads[] = {
         "Last-Modified: Wed, 15 Nov 1995 04:58:08 GMT\r\n"
         "Server: SomeBadServer/5\r\n"
         "Content-Length: %d\r\n"
-        "Content-Type: multipart/byteranges;\t foo; boundarY=%s\r\n"
+        "Content-Type: multipart/byteranges;\t foo=bar; boundarY=%s\r\n"
         "\r\n"
     ),
     // normal 206 2 with strange ows
@@ -589,7 +589,7 @@ static const cat_const_string_t multipart_req_heads[] = {
         "Last-Modified: Wed, 15 Nov 1995 04:58:08 GMT\r\n"
         "Server: SomeBadServer/5\r\n"
         "Content-Length: %d\r\n"
-        "Content-Type:   \t  multipart/byteranges;\t foo; boundarY=%s\r\n"
+        "Content-Type:   \t  multipart/byteranges;\t foo=bar; boundarY=%s\r\n"
         "\r\n"
     ),
 };
@@ -604,12 +604,9 @@ const cat_const_string_t common_head = cat_const_string(
     "\r\n"
 );
 
-static struct {
-    const cat_const_string_t head;
-    int error;
-} multipart_req_heads_bad[] = {
+static const cat_const_string_t multipart_req_heads_bad[] = {
     // no boundary
-    { cat_const_string(
+    cat_const_string(
         "POST /upload HTTP/1.1\r\n"
         "Host: www.foo.com\r\n"
         "User-Agent: SomeBadBot/1\r\n"
@@ -618,9 +615,9 @@ static struct {
         "X-Not-boundary: %s\r\n"
         "Content-Type: MultiPart/fORm\r\n"
         "\r\n"
-    ), CAT_EHP_MULTIPART_HEADER },
+    ),
     // no boundary
-    { cat_const_string(
+    cat_const_string(
         "POST /upload HTTP/1.1\r\n"
         "Host: www.foo.com\r\n"
         "User-Agent: SomeBadBot/2\r\n"
@@ -628,9 +625,9 @@ static struct {
         "Content-Length: %d\r\n"
         "Content-Type: MultiPart/fORm;\t charsEt=utF-8;miao=%s  ;\r\n"
         "\r\n"
-    ), CAT_EHP_MULTIPART_HEADER },
+    ),
     // duplicate content-type
-    { cat_const_string(
+    cat_const_string(
         "POST /upload HTTP/1.1\r\n"
         "Host: www.foo.com\r\n"
         "User-Agent: SomeBadBot/3\r\n"
@@ -639,28 +636,28 @@ static struct {
         "Content-Type: application/json  ;\r\n"
         "Content-Type: MultiPart/fORm;\t charsEt=utF-8;boundary=%s  ;\r\n"
         "\r\n"
-    ), CAT_EHP_DUPLICATE_CONTENT_TYPE },
-    // duplicate content-type
-    { cat_const_string(
-        "HTTP/1.1 206 Partial Content\r\n"
-        "Date: Wed, 15 Nov 1995 06:25:24 GMT\r\n"
-        "Last-Modified: Wed, 15 Nov 1995 04:58:08 GMT\r\n"
-        "Server: SomeBadServer/4\r\n"
-        "Content-Length: %d\r\n"
-        "Content-Type: multipart/byteranges;\t boundary=%s\r\n"
-        "Content-Type: application/json\r\n"
-        "\r\n"
-    ), CAT_EHP_DUPLICATE_CONTENT_TYPE },
-    // duplicate boundary
-    { cat_const_string(
-        "HTTP/1.1 206 Partial Content\r\n"
-        "Date: Wed, 15 Nov 1995 06:25:24 GMT\r\n"
-        "Last-Modified: Wed, 15 Nov 1995 04:58:08 GMT\r\n"
-        "Server: SomeBadServer/5\r\n"
-        "Content-Length: %d\r\n"
-        "Content-Type: multipart/byteranges;\t boundary=%s; boundary=cafe\r\n"
-        "\r\n"
-    ), CAT_EHP_MULTIPART_HEADER },
+    ),
+    // // duplicate content-type
+    // cat_const_string(
+    //     "HTTP/1.1 206 Partial Content\r\n"
+    //     "Date: Wed, 15 Nov 1995 06:25:24 GMT\r\n"
+    //     "Last-Modified: Wed, 15 Nov 1995 04:58:08 GMT\r\n"
+    //     "Server: SomeBadServer/4\r\n"
+    //     "Content-Length: %d\r\n"
+    //     "Content-Type: multipart/byteranges;\t boundary=%s\r\n"
+    //     "Content-Type: application/json\r\n"
+    //     "\r\n"
+    // ),
+    // // duplicate boundary
+    // cat_const_string(
+    //     "HTTP/1.1 206 Partial Content\r\n"
+    //     "Date: Wed, 15 Nov 1995 06:25:24 GMT\r\n"
+    //     "Last-Modified: Wed, 15 Nov 1995 04:58:08 GMT\r\n"
+    //     "Server: SomeBadServer/5\r\n"
+    //     "Content-Length: %d\r\n"
+    //     "Content-Type: multipart/byteranges;\t boundary=%s; boundary=cafe\r\n"
+    //     "\r\n"
+    // )
 };
 
 static struct {
@@ -669,17 +666,11 @@ static struct {
 } boundaries[] = {
     {"cafebabe", "cafebabe"},
     {"\"cafebabe\"", "cafebabe"},
-    {"\"cafebabe\" \t", "cafebabe"},
-    {"cafebabe\t", "cafebabe"},
-    {"cafebabe\t ", "cafebabe"},
-    {"cafebabe \t", "cafebabe"},
-    {"dix's bound-ary_1:OK", "dix's bound-ary_1:OK"},
+    //{"dix's bound-ary_1:OK", "dix's bound-ary_1:OK"}, // not legal, invalid char
     {"\"dix's bound-ary_1:OK\"", "dix's bound-ary_1:OK"},
-    {"foo bar", "foo bar"},
-    {"foo bar ", "foo bar"},
-    {"\"foo bar\" ", "foo bar"},
-    {" foo bar ", " foo bar"},
-    {"\" foo bar\" ", " foo bar"},
+    //{"foo bar", "foo bar"}, // not legal, invalid char
+    {"\"foo bar\"", "foo bar"},
+    {"\" foo bar\"", " foo bar"},
     {
         "1234567890"
         "2234567890"
@@ -718,7 +709,15 @@ static const char *boundaries_bad[] = {
     "e=mc^2", // bad char
     "{}cafebabe", // bad char
     "\"cafebabe", // unmatched quote
+    "cafebabe\t", // extra part
+    "cafebabe\t ", // extra part
+    "cafebabe \t", // extra part
+    "\"cafebabe\" \t", // extra part
     "\"cafebabe\" ceshi", // extra part
+    "foo bar", // bad char
+    "foo bar ", // extra part + bad char
+    " foo bar", // extra part
+    "\" foo bar\" ", // extra part
     "1234567890"
     "2234567890"
     "3234567890"
@@ -1398,15 +1397,16 @@ TEST(cat_http_parser, multipart_bad_boundaries)
             CAT_LOG_DEBUG_V3(TEST_HTTP, "Parsing data:\n%.*s\n\n", head_len + body_len, head_buf);
             const char *p = head_buf;
             const char *pe = &head_buf[head_len + body_len];
-            while (true) {
+            while (!cat_http_parser_is_completed(&parser)) {
                 if (!cat_http_parser_execute(&parser, p, pe - p)) {
                     CAT_LOG_DEBUG(TEST_HTTP, "Parsing failed with: %d: %s", cat_get_last_error_code(), cat_get_last_error_message());
-                    ASSERT_EQ(cat_get_last_error_code(), CAT_EHP_MULTIPART_HEADER);
+                    FAIL();
                     break;
                 }
-                ASSERT_FALSE(cat_http_parser_is_completed(&parser));
                 p = cat_http_parser_get_current_pos(&parser);
+                ASSERT_EQ(parser.event & (cat_http_parser_event_t)CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART, 0);
             }
+            ASSERT_TRUE(cat_http_parser_is_completed(&parser));
             // use create to avoid res/req change
             cat_http_parser_create(&parser);
             cat_http_parser_set_events(&parser, CAT_HTTP_PARSER_EVENTS_ALL);
@@ -1431,20 +1431,20 @@ TEST(cat_http_parser, multipart_bad_heads)
             const char *boundary = boundaries[j].literal;
             const char *boundary_real = boundaries[j].real;
             int body_len = snprintf(CAT_STRS(body_buf), multipart_req_body.data, boundary_real, boundary_real, boundary_real);
-            int head_len = snprintf(CAT_STRS(head_buf), multipart_req_heads_bad[i].head.data, body_len, boundary);
+            int head_len = snprintf(CAT_STRS(head_buf), multipart_req_heads_bad[i].data, body_len, boundary);
             memcpy(&head_buf[head_len], body_buf, body_len);
             head_buf[head_len + body_len] = '\0';
             CAT_LOG_DEBUG_V3(TEST_HTTP, "Parsing data:\n%.*s\n\n", head_len + body_len, head_buf);
             const char *p = head_buf;
             const char *pe = &head_buf[head_len + body_len];
-            while (true) {
+            while (!cat_http_parser_is_completed(&parser)) {
                 if (!cat_http_parser_execute(&parser, p, pe - p)) {
                     CAT_LOG_DEBUG(TEST_HTTP, "Parsing failed with: %d: %s", cat_get_last_error_code(), cat_get_last_error_message());
-                    ASSERT_EQ(cat_get_last_error_code(), multipart_req_heads_bad[i].error);
+                    FAIL();
                     break;
                 }
-                ASSERT_FALSE(cat_http_parser_is_completed(&parser));
                 p = cat_http_parser_get_current_pos(&parser);
+                ASSERT_EQ(parser.event & (cat_http_parser_event_t)CAT_HTTP_PARSER_EVENT_FLAG_MULTIPART, 0);
             }
             // use create to avoid res/req change
             cat_http_parser_create(&parser);


### PR DESCRIPTION
还是手写的，性能与未改之前的持平，比ragel生成的那个快亿点点
与 #22 冲突

bc:
1. content-type为空，重复时parser不再报错，继续parse（但不启用multipart parser）
2. 取消了multipart相关的大多数错误码（但比起ragel的，更容易做回来）
3. 对于boundary的parse更严格了，基本严格按照相关RFC来

相关： https://github.com/swow/swow/issues/186
